### PR TITLE
v1.4.0 — AI-Native Foundation (MCP + Indicators v2 + AI context + Easy-mode + Watchlist)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,6 @@ test-outputs
 # Claude
 CLAUDE.md
 .claude/
+.mcp.json
 docs/plans/
 docs/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 1.4.0 — AI-Native Foundation
+
+Repositioning vnstock-js từ "VN stock SDK" sang "AI Research Toolkit cho cổ phiếu Việt Nam". Bundle MCP server + indicators v2 + AI context layer + easy-mode helpers + watchlist trong 1 release.
+
+### Thêm
+
+- **MCP server** (`vnstock mcp` subcommand) — stdio MCP server cho Claude Desktop / Cursor / VS Code. 11 tools bilingual (Vi + En):
+  - 8 data tools: `get_quote`, `get_history`, `search_symbols`, `list_symbols`, `top_movers`, `is_trade_day`, `get_trading_calendar`, `get_company_info`
+  - 3 AI primitives: `get_ai_context`, `to_ai_prompt`, `compare_symbols`
+  - Session cache (30s quote, 60s aiContext) giảm pressure VCI
+  - Dynamic import → CLI startup không bị regress
+- **Indicators v2** — bổ sung SMA/EMA/RSI có sẵn:
+  - `macd(candles, opts?)` — 12/26/9 default, configurable fast/slow/signal
+  - `bollinger(candles, opts?)` — 20-period 2-stddev, trả thêm `percentB` (0..1)
+  - `atr(candles, period?)` — Wilder smoothing, default 14-period
+- **AI context layer:**
+  - `vnstock.stock.aiContext(symbol)` — structured JSON: trend (bullish/bearish/neutral), indicators snapshot (RSI/MACD/SMA/EMA/Bollinger/ATR), pivot S/R, volume z-score, performance 1d/7d/30d/90d
+  - `vnstock.stock.toAIPrompt(symbol, { lang })` — plain-text format cho non-MCP LLM (GPT/Gemini/local)
+  - Trend classifier rules-based (EMA chain + slope)
+  - S/R bằng swing pivot points (5-day window)
+- **Easy-mode helpers** top-level:
+  - `vnstock.quickQuote("VCB")` — giá hiện tại + change %
+  - `vnstock.recentHistory("VCB", 30)` — N phiên gần nhất
+  - `vnstock.compareSymbols(["VCB","TCB"])` — side-by-side
+  - `vnstock.topMovers()` — gainers + losers cùng response
+- **Watchlist module** `vnstock.watchlist`:
+  - CRUD: `create/delete/add/remove/list/listAll/has`
+  - Persist Node: `~/.vnstock-js/watchlist.json` (atomic rename)
+  - Browser: no-op + warn, inject custom via `setStorage(adapter)`
+  - Auto-uppercase, dedup symbols
+
+### Nội bộ
+
+- Dependency mới: `@modelcontextprotocol/sdk@^1.29.0`
+- 83 new tests (24 indicators + 16 ai-context + 4 easy-mode + 12 watchlist + 27 mcp)
+- Pure-function indicators v2 (không network), AI context layer compose lại — testable mock-based
+
+### Migration notes
+
+Không breaking. v1.3.x code chạy y nguyên. Features mới opt-in.
+
+Cài MCP server vào Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "vnstock": {
+      "command": "npx",
+      "args": ["-y", "vnstock-js", "mcp"]
+    }
+  }
+}
+```
+
 ## 1.3.3
 
 ### Thêm

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Thư viện JavaScript/TypeScript lấy dữ liệu thị trường chứng kho�
 - **Hàng hóa** -- Giá vàng (BTMC, SJC, GiaVang.net), tỷ giá VCB
 - **Tin tức** -- Tổng hợp tin tài chính VN hàng ngày (Vietstock, VnExpress, Tin Nhanh CK, ...)
 - **Realtime** -- WebSocket dữ liệu giá trực tiếp (SSI)
+- **Chỉ báo kỹ thuật** -- SMA, EMA, RSI, MACD, Bollinger Bands, ATR
+- **AI context** -- `aiContext()` trả structured trend/RSI/MACD/S-R/volume cho LLM reasoning
+- **MCP server** -- `vnstock mcp` cho Claude Desktop / Cursor / VS Code
+- **Watchlist** -- quản lý danh sách mã yêu thích, persist `~/.vnstock-js/watchlist.json`
 - **CLI** -- Command-line tool `vnstock` cho terminal users
 - **TypeScript** -- Đầy đủ type definitions
 
@@ -159,13 +163,115 @@ Tùy chọn:
 ## Chỉ báo kỹ thuật
 
 ```ts
-import { sma, ema, rsi } from 'vnstock-js';
+import { sma, ema, rsi, macd, bollinger, atr } from 'vnstock-js';
 
 const history = await stock.quote({ ticker: 'FPT', start: '2024-01-01' });
 
 const sma20 = sma(history, { period: 20 });
 const ema12 = ema(history, { period: 12 });
 const rsi14 = rsi(history);
+const macdData = macd(history);                        // 12/26/9 default
+const bb = bollinger(history, { period: 20, stddev: 2 });
+const atr14 = atr(history, 14);
+```
+
+## AI context — phân tích kỹ thuật cho LLM (v1.4+)
+
+```ts
+import vnstock from 'vnstock-js';
+
+// Structured JSON cho AI reasoning
+const ctx = await vnstock.stock.aiContext('VCB');
+console.log(ctx.trend);     // { direction: 'bullish', strength: 0.7, rationale: '...' }
+console.log(ctx.indicators);// RSI, MACD, SMA, EMA, Bollinger, ATR
+console.log(ctx.levels);    // { support: [...], resistance: [...] }
+
+// Plain-text format để dán vào GPT/Gemini bên ngoài
+const text = await vnstock.stock.toAIPrompt('VCB', { lang: 'vi' });
+```
+
+## MCP server — hỏi Claude về cổ phiếu VN (v1.4+)
+
+vnstock-js đi kèm MCP (Model Context Protocol) server expose 11 tools cho Claude:
+
+- 8 data tools: `get_quote`, `get_history`, `search_symbols`, `list_symbols`, `top_movers`, `is_trade_day`, `get_trading_calendar`, `get_company_info`
+- 3 AI tools: `get_ai_context` (structured technical analysis), `to_ai_prompt` (plain-text), `compare_symbols`
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json`:
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "vnstock": {
+      "command": "npx",
+      "args": ["-y", "vnstock-js", "mcp"]
+    }
+  }
+}
+```
+
+Reload Claude Desktop và hỏi: "giá VCB hôm nay", "phân tích kỹ thuật MBB", "so sánh VCB TCB MBB"...
+
+### Claude Code CLI
+
+User-scope (toàn cục, mọi project dùng được):
+
+```bash
+claude mcp add --scope user vnstock npx -y vnstock-js mcp
+claude mcp list   # verify: "vnstock: ... - ✓ Connected"
+```
+
+Project-scope (commit `.mcp.json` chia sẻ team):
+
+```bash
+claude mcp add --scope project vnstock npx -y vnstock-js mcp
+```
+
+Project-scope MCP cần approve trong session đầu: gõ `/mcp` trong Claude Code → approve `vnstock`.
+
+### Cursor / VS Code
+
+Tương tự config schema, xem docs MCP của từng client.
+
+### Test queries
+
+Sau khi setup xong, gõ trong Claude:
+
+| Query | Tool gọi |
+|---|---|
+| `giá VCB hôm nay` | `get_quote` |
+| `phân tích kỹ thuật VCB` | `get_ai_context` |
+| `xuất context VCB sang text` | `to_ai_prompt` |
+| `so sánh VCB và TCB` | `compare_symbols` |
+| `top tăng giảm hôm nay` | `top_movers` |
+| `30/4/2026 có giao dịch không` | `is_trade_day` |
+| `tìm mã ngân hàng` | `search_symbols` |
+| `FPT 30 phiên qua` | `get_history` |
+
+## Easy-mode helpers (v1.4+)
+
+```ts
+import { quickQuote, recentHistory, compareSymbols, topMovers } from 'vnstock-js';
+
+const q = await quickQuote('VCB');           // { symbol, price, change, volume, ... }
+const last30 = await recentHistory('VCB', 30);
+const cmp = await compareSymbols(['VCB', 'TCB', 'MBB']);
+const movers = await topMovers();             // { gainers, losers }
+```
+
+## Watchlist (v1.4+)
+
+```ts
+import { watchlist } from 'vnstock-js';
+
+await watchlist.create('banks');
+await watchlist.add('banks', ['VCB', 'TCB', 'MBB']);
+const symbols = await watchlist.list('banks');
+// Persist tại ~/.vnstock-js/watchlist.json (Node)
 ```
 
 ## API nâng cao

--- a/__tests__/ai-context.test.ts
+++ b/__tests__/ai-context.test.ts
@@ -1,0 +1,201 @@
+import {
+  classifyTrend,
+  snapshotIndicators,
+  classifyVolume,
+  computePerformance,
+  buildAIContext,
+  formatAIPrompt,
+} from "../src/core/stock/ai-context";
+import { detectPivots } from "../src/core/stock/pivot";
+import { QuoteHistory } from "../src/models/normalized";
+
+function makeUptrend(n: number): QuoteHistory[] {
+  const data: QuoteHistory[] = [];
+  for (let i = 0; i < n; i++) {
+    const base = 100 + i * 0.5;
+    data.push({
+      date: `2024-${String(Math.floor(i / 30) + 1).padStart(2, "0")}-${String((i % 30) + 1).padStart(2, "0")}`,
+      open: base,
+      high: base + 1,
+      low: base - 0.5,
+      close: base + 0.5,
+      volume: 1_000_000 + i * 1000,
+    });
+  }
+  return data;
+}
+
+function makeDowntrend(n: number): QuoteHistory[] {
+  const data: QuoteHistory[] = [];
+  for (let i = 0; i < n; i++) {
+    const base = 200 - i * 0.5;
+    data.push({
+      date: `2024-${String(Math.floor(i / 30) + 1).padStart(2, "0")}-${String((i % 30) + 1).padStart(2, "0")}`,
+      open: base,
+      high: base + 0.5,
+      low: base - 1,
+      close: base - 0.5,
+      volume: 1_000_000,
+    });
+  }
+  return data;
+}
+
+describe("classifyTrend", () => {
+  it("detects bullish uptrend", () => {
+    const r = classifyTrend(makeUptrend(220));
+    expect(r.direction).toBe("bullish");
+    expect(r.strength).toBeGreaterThan(0);
+    expect(r.rationale).toContain("EMA");
+  });
+
+  it("detects bearish downtrend", () => {
+    const r = classifyTrend(makeDowntrend(220));
+    expect(r.direction).toBe("bearish");
+  });
+
+  it("returns neutral when data < 50 candles", () => {
+    const r = classifyTrend(makeUptrend(30));
+    expect(r.direction).toBe("neutral");
+    expect(r.strength).toBe(0);
+  });
+});
+
+describe("snapshotIndicators", () => {
+  it("returns last values for 220-candle uptrend", () => {
+    const snap = snapshotIndicators(makeUptrend(220));
+    expect(snap.rsi14).not.toBeNull();
+    expect(snap.macd.line).not.toBeNull();
+    expect(snap.sma[20]).not.toBeNull();
+    expect(snap.sma[200]).not.toBeNull();
+    expect(snap.bollinger.percentB).not.toBeNull();
+    expect(snap.atr14).not.toBeNull();
+  });
+
+  it("gracefully handles short data (< 200)", () => {
+    const snap = snapshotIndicators(makeUptrend(60));
+    expect(snap.sma[200]).toBeNull();
+    expect(snap.ema[200]).toBeNull();
+    expect(snap.sma[20]).not.toBeNull();
+    expect(snap.sma[50]).not.toBeNull();
+  });
+});
+
+describe("classifyVolume", () => {
+  it("returns normal for stable volume", () => {
+    const data = makeUptrend(30).map((c) => ({ ...c, volume: 1_000_000 }));
+    const v = classifyVolume(data);
+    expect(v.signal).toBe("normal");
+    expect(Math.abs(v.zscore)).toBeLessThan(1);
+  });
+
+  it("detects above_average spike (constant baseline fallback)", () => {
+    const data = makeUptrend(30).map((c) => ({ ...c, volume: 1_000_000 }));
+    data[data.length - 1].volume = 10_000_000;
+    const v = classifyVolume(data);
+    expect(v.signal).toBe("above_average");
+    expect(v.zscore).toBeGreaterThan(1);
+  });
+
+  it("detects above_average spike (variable baseline)", () => {
+    const data = makeUptrend(30).map((c, i) => ({ ...c, volume: 1_000_000 + (i % 5) * 50_000 }));
+    data[data.length - 1].volume = 10_000_000;
+    const v = classifyVolume(data);
+    expect(v.signal).toBe("above_average");
+    expect(v.zscore).toBeGreaterThan(2);
+  });
+
+  it("returns normal when < 21 candles", () => {
+    const data = makeUptrend(10);
+    const v = classifyVolume(data);
+    expect(v.signal).toBe("normal");
+    expect(v.zscore).toBe(0);
+  });
+});
+
+describe("computePerformance", () => {
+  it("computes change windows", () => {
+    const data = makeUptrend(100);
+    const p = computePerformance(data);
+    expect(p.change1d).not.toBeNull();
+    expect(p.change7d).not.toBeNull();
+    expect(p.change30d).not.toBeNull();
+    expect(p.change90d).not.toBeNull();
+    expect(p.change1d as number).toBeGreaterThan(0);
+  });
+
+  it("returns null for short data", () => {
+    const data = makeUptrend(20);
+    const p = computePerformance(data);
+    expect(p.change1d).not.toBeNull();
+    expect(p.change30d).toBeNull();
+    expect(p.change90d).toBeNull();
+  });
+});
+
+describe("detectPivots", () => {
+  it("finds swing highs and lows in synthetic data with peaks", () => {
+    // create data with explicit peak at i=10 and trough at i=20
+    const data: QuoteHistory[] = [];
+    for (let i = 0; i < 30; i++) {
+      const base = 100;
+      let high = base + 1;
+      let low = base - 1;
+      if (i === 10) { high = 120; low = 119; }
+      if (i === 20) { high = 81; low = 80; }
+      data.push({
+        date: `2024-01-${String(i + 1).padStart(2, "0")}`,
+        open: base, high, low, close: base, volume: 0,
+      });
+    }
+    const pivots = detectPivots(data, { window: 3, topN: 3 });
+    expect(pivots.resistance.length + pivots.support.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty when data too short", () => {
+    const data = makeUptrend(5);
+    const pivots = detectPivots(data);
+    expect(pivots.support).toEqual([]);
+    expect(pivots.resistance).toEqual([]);
+  });
+});
+
+describe("buildAIContext (integration via mock adapter)", () => {
+  it("composes full context from mock adapter", async () => {
+    const mockAdapter: any = {
+      fetchQuoteHistory: jest.fn().mockResolvedValue(makeUptrend(220)),
+    };
+    const ctx = await buildAIContext(mockAdapter, "VCB");
+    expect(ctx.symbol).toBe("VCB");
+    expect(ctx.asOf).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(ctx.trend.direction).toBe("bullish");
+    expect(ctx.indicators.rsi14).not.toBeNull();
+    expect(ctx.performance.change30d).not.toBeNull();
+  });
+});
+
+describe("formatAIPrompt", () => {
+  it("vi output contains expected labels", async () => {
+    const mockAdapter: any = {
+      fetchQuoteHistory: jest.fn().mockResolvedValue(makeUptrend(220)),
+    };
+    const ctx = await buildAIContext(mockAdapter, "VCB");
+    const text = formatAIPrompt(ctx, "vi");
+    expect(text).toContain("Trend:");
+    expect(text).toContain("RSI(14)");
+    expect(text).toContain("MACD");
+    expect(text).toContain("Support:");
+    expect(text).toContain("Resistance:");
+    expect(text).toContain("Change:");
+  });
+
+  it("en output contains English labels", async () => {
+    const mockAdapter: any = {
+      fetchQuoteHistory: jest.fn().mockResolvedValue(makeUptrend(220)),
+    };
+    const ctx = await buildAIContext(mockAdapter, "VCB");
+    const text = formatAIPrompt(ctx, "en");
+    expect(text).toContain("Trend:");
+    expect(text).toContain("Bollinger %B:");
+  });
+});

--- a/__tests__/cli/mcp/handlers.test.ts
+++ b/__tests__/cli/mcp/handlers.test.ts
@@ -1,0 +1,231 @@
+jest.mock("../../../src/runtime", () => {
+  const mockAdapter = {
+    fetchQuoteHistory: jest.fn(),
+  };
+  const stockMock = {
+    trading: {
+      priceBoard: jest.fn(),
+      topGainers: jest.fn(),
+      topLosers: jest.fn(),
+    },
+    quote: {
+      history: jest.fn(),
+    },
+    aiContext: jest.fn(),
+    toAIPrompt: jest.fn(),
+    adapter: mockAdapter,
+  };
+  return {
+    Vnstock: jest.fn().mockImplementation(() => ({
+      stock: stockMock,
+      __mock: stockMock,
+    })),
+  };
+});
+
+jest.mock("../../../src/data", () => ({
+  init: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../../src/core/listing/directory", () => ({
+  Directory: {
+    getBySymbol: jest.fn(),
+    getByExchange: jest.fn(),
+    search: jest.fn(),
+  },
+}));
+
+jest.mock("../../../src/core/market", () => ({
+  calendar: {
+    isTradeDay: jest.fn(),
+    holidays: jest.fn(),
+  },
+}));
+
+import { handlers } from "../../../src/cli/mcp/handlers";
+import { Vnstock } from "../../../src/runtime";
+import { Directory } from "../../../src/core/listing/directory";
+import { calendar } from "../../../src/core/market";
+
+const stockMock = (new (Vnstock as any)() as any).__mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MCP handlers — group A (basic data tools)", () => {
+  describe("get_quote", () => {
+    it("returns error if symbol missing", async () => {
+      const res = await handlers.get_quote({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns error if symbol not found", async () => {
+      stockMock.trading.priceBoard.mockResolvedValueOnce([]);
+      const res = await handlers.get_quote({ symbol: "XYZ" });
+      expect(res.isError).toBe(true);
+      expect(res.content[0].text).toContain("Không tìm thấy");
+    });
+
+    it("returns content with text + JSON for valid symbol", async () => {
+      stockMock.trading.priceBoard.mockResolvedValueOnce([
+        { symbol: "VCB", companyName: "Vietcombank", price: 59.3, percentPriceChange: 0.0017, totalVolume: 5_000_000, ceilingPrice: 63, floorPrice: 55, referencePrice: 59 },
+      ]);
+      const res = await handlers.get_quote({ symbol: "VCB" });
+      expect(res.isError).toBeUndefined();
+      expect(res.content.length).toBe(2);
+      expect(res.content[0].text).toContain("VCB");
+    });
+  });
+
+  describe("get_history", () => {
+    it("returns error if symbol missing", async () => {
+      const res = await handlers.get_history({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("calls quote.history with computed dates", async () => {
+      stockMock.quote.history.mockResolvedValueOnce([
+        { date: "2026-05-01", open: 1, high: 1, low: 1, close: 1, volume: 1 },
+        { date: "2026-05-02", open: 1, high: 1, low: 1, close: 1, volume: 1 },
+      ]);
+      const res = await handlers.get_history({ symbol: "VCB", limit: 5 });
+      expect(res.isError).toBeUndefined();
+      expect(stockMock.quote.history).toHaveBeenCalled();
+    });
+  });
+
+  describe("search_symbols", () => {
+    it("returns error if query missing", async () => {
+      const res = await handlers.search_symbols({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns results", async () => {
+      (Directory.search as jest.Mock).mockReturnValue([{ symbol: "VCB", companyName: "X" }]);
+      const res = await handlers.search_symbols({ query: "vietcom" });
+      expect(res.isError).toBeUndefined();
+      expect(Directory.search).toHaveBeenCalledWith("vietcom", { limit: 10 });
+    });
+  });
+
+  describe("list_symbols", () => {
+    it("filters by exchange when provided", async () => {
+      (Directory.getByExchange as jest.Mock).mockReturnValue([{ symbol: "VCB" }]);
+      const res = await handlers.list_symbols({ exchange: "hose" });
+      expect(res.isError).toBeUndefined();
+      expect(Directory.getByExchange).toHaveBeenCalledWith("HOSE");
+    });
+  });
+
+  describe("top_movers", () => {
+    it("returns gainers + losers", async () => {
+      stockMock.trading.topGainers.mockResolvedValueOnce([{ symbol: "AAA" }]);
+      stockMock.trading.topLosers.mockResolvedValueOnce([{ symbol: "BBB" }]);
+      const res = await handlers.top_movers({});
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[1].text);
+      expect(data.gainers.length).toBe(1);
+      expect(data.losers.length).toBe(1);
+    });
+  });
+
+  describe("is_trade_day", () => {
+    it("returns boolean from calendar", async () => {
+      (calendar.isTradeDay as jest.Mock).mockReturnValue(true);
+      const res = await handlers.is_trade_day({ date: "2026-05-14" });
+      expect(res.isError).toBeUndefined();
+      expect(res.content[0].text).toContain("có giao dịch");
+    });
+  });
+
+  describe("get_trading_calendar", () => {
+    it("returns error if year invalid", async () => {
+      const res = await handlers.get_trading_calendar({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns holidays for year", async () => {
+      (calendar.holidays as jest.Mock).mockReturnValue(["2026-01-01"]);
+      const res = await handlers.get_trading_calendar({ year: 2026 });
+      expect(res.isError).toBeUndefined();
+      const data = JSON.parse(res.content[1].text);
+      expect(data.year).toBe(2026);
+    });
+  });
+
+  describe("get_company_info", () => {
+    it("returns error if symbol not found", async () => {
+      (Directory.getBySymbol as jest.Mock).mockReturnValue(null);
+      const res = await handlers.get_company_info({ symbol: "XYZ" });
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns company info", async () => {
+      (Directory.getBySymbol as jest.Mock).mockReturnValue({
+        symbol: "VCB",
+        companyName: "Vietcombank",
+        exchange: "HSX",
+      });
+      const res = await handlers.get_company_info({ symbol: "VCB" });
+      expect(res.isError).toBeUndefined();
+    });
+  });
+});
+
+describe("MCP handlers — group B (AI primitives)", () => {
+  describe("get_ai_context", () => {
+    it("returns error if symbol missing", async () => {
+      const res = await handlers.get_ai_context({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns context with trend summary", async () => {
+      stockMock.aiContext.mockResolvedValueOnce({
+        symbol: "VCB",
+        asOf: "2026-05-14",
+        trend: { direction: "bullish", strength: 0.7, rationale: "x" },
+        indicators: {},
+        levels: { support: [], resistance: [] },
+        volume: { today: 0, avg20: 0, signal: "normal", zscore: 0 },
+        performance: {},
+      });
+      const res = await handlers.get_ai_context({ symbol: "VCB" });
+      expect(res.isError).toBeUndefined();
+      expect(res.content[0].text).toContain("bullish");
+    });
+  });
+
+  describe("to_ai_prompt", () => {
+    it("returns plain-text via toAIPrompt", async () => {
+      stockMock.toAIPrompt.mockResolvedValueOnce("=== VCB ===\nTrend: bullish");
+      const res = await handlers.to_ai_prompt({ symbol: "VCB" });
+      expect(res.isError).toBeUndefined();
+      expect(res.content[0].text).toContain("Trend");
+    });
+  });
+
+  describe("compare_symbols", () => {
+    it("returns error if < 2 symbols", async () => {
+      const res = await handlers.compare_symbols({ symbols: ["VCB"] });
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns error if > 10 symbols", async () => {
+      const res = await handlers.compare_symbols({
+        symbols: Array.from({ length: 11 }, (_, i) => "S" + i),
+      });
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns priceBoard data for 2-10 symbols", async () => {
+      stockMock.trading.priceBoard.mockResolvedValueOnce([
+        { symbol: "VCB", price: 59 },
+        { symbol: "TCB", price: 28 },
+      ]);
+      const res = await handlers.compare_symbols({ symbols: ["vcb", "tcb"] });
+      expect(res.isError).toBeUndefined();
+      expect(stockMock.trading.priceBoard).toHaveBeenCalledWith(["VCB", "TCB"]);
+    });
+  });
+});

--- a/__tests__/cli/mcp/schemas.test.ts
+++ b/__tests__/cli/mcp/schemas.test.ts
@@ -1,0 +1,59 @@
+import { tools } from "../../../src/cli/mcp/tools";
+
+describe("MCP tool schemas", () => {
+  it("registers exactly 11 tools", () => {
+    expect(tools.length).toBe(11);
+  });
+
+  it("expected tool names present", () => {
+    const names = tools.map((t) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "get_quote",
+        "get_history",
+        "search_symbols",
+        "list_symbols",
+        "top_movers",
+        "is_trade_day",
+        "get_trading_calendar",
+        "get_company_info",
+        "get_ai_context",
+        "to_ai_prompt",
+        "compare_symbols",
+      ])
+    );
+  });
+
+  it("each tool has type object schema", () => {
+    for (const t of tools) {
+      expect(t.inputSchema.type).toBe("object");
+      expect(typeof t.inputSchema.properties).toBe("object");
+    }
+  });
+
+  it("each tool has description ≥ 50 chars (Vi + En context)", () => {
+    for (const t of tools) {
+      expect(t.description.length).toBeGreaterThanOrEqual(50);
+    }
+  });
+
+  it("descriptions are bilingual (contain 'EN:' marker)", () => {
+    for (const t of tools) {
+      expect(t.description).toContain("EN:");
+    }
+  });
+
+  it("required fields exist in properties", () => {
+    for (const t of tools) {
+      const required = t.inputSchema.required || [];
+      for (const field of required) {
+        expect(t.inputSchema.properties).toHaveProperty(field);
+      }
+    }
+  });
+
+  it("tool names are unique", () => {
+    const names = tools.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/__tests__/indicators/atr.test.ts
+++ b/__tests__/indicators/atr.test.ts
@@ -1,0 +1,72 @@
+import { atr } from "../../src/indicators/atr";
+
+describe("atr", () => {
+  // 15 candles, simple HLC
+  const data = [
+    { date: "2024-01-01", open: 10, high: 11, low: 9, close: 10, volume: 0 },
+    { date: "2024-01-02", open: 10, high: 12, low: 10, close: 11, volume: 0 },
+    { date: "2024-01-03", open: 11, high: 13, low: 11, close: 12, volume: 0 },
+    { date: "2024-01-04", open: 12, high: 14, low: 12, close: 13, volume: 0 },
+    { date: "2024-01-05", open: 13, high: 15, low: 13, close: 14, volume: 0 },
+    { date: "2024-01-06", open: 14, high: 16, low: 14, close: 15, volume: 0 },
+    { date: "2024-01-07", open: 15, high: 17, low: 15, close: 16, volume: 0 },
+    { date: "2024-01-08", open: 16, high: 18, low: 16, close: 17, volume: 0 },
+    { date: "2024-01-09", open: 17, high: 19, low: 17, close: 18, volume: 0 },
+    { date: "2024-01-10", open: 18, high: 20, low: 18, close: 19, volume: 0 },
+    { date: "2024-01-11", open: 19, high: 21, low: 19, close: 20, volume: 0 },
+    { date: "2024-01-12", open: 20, high: 22, low: 20, close: 21, volume: 0 },
+    { date: "2024-01-13", open: 21, high: 23, low: 21, close: 22, volume: 0 },
+    { date: "2024-01-14", open: 22, high: 24, low: 22, close: 23, volume: 0 },
+    { date: "2024-01-15", open: 23, high: 25, low: 23, close: 24, volume: 0 },
+  ];
+
+  it("returns same length as input", () => {
+    const result = atr(data, 14);
+    expect(result).toHaveLength(15);
+  });
+
+  it("first period-1 entries are null", () => {
+    const result = atr(data, 14);
+    for (let i = 0; i < 13; i++) {
+      expect(result[i].atr).toBeNull();
+    }
+    expect(result[13].atr).not.toBeNull();
+  });
+
+  it("computes ATR with Wilder smoothing", () => {
+    // After 14 candles: TR[0]=2, TR[1..14] each ~2 (high-low=2, prev close diff small)
+    // Initial ATR(14) = avg(TR[0..13]) ≈ 2
+    const result = atr(data, 14);
+    expect(result[13].atr as number).toBeGreaterThan(1.5);
+    expect(result[13].atr as number).toBeLessThan(2.5);
+  });
+
+  it("ATR continues to smooth on subsequent bars", () => {
+    const result = atr(data, 14);
+    expect(result[14].atr).not.toBeNull();
+    // Wilder: new = (old * 13 + tr) / 14
+    const prev = result[13].atr as number;
+    const cur = result[14].atr as number;
+    expect(Math.abs(cur - prev)).toBeLessThan(prev); // small change
+  });
+
+  it("preserves dates", () => {
+    const result = atr(data, 14);
+    expect(result[0].date).toBe("2024-01-01");
+    expect(result[14].date).toBe("2024-01-15");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(atr([], 14)).toEqual([]);
+  });
+
+  it("throws on period < 1", () => {
+    expect(() => atr(data, 0)).toThrow();
+  });
+
+  it("uses default period of 14", () => {
+    const r1 = atr(data);
+    const r2 = atr(data, 14);
+    expect(r1[14].atr).toBeCloseTo(r2[14].atr as number);
+  });
+});

--- a/__tests__/indicators/bollinger.test.ts
+++ b/__tests__/indicators/bollinger.test.ts
@@ -1,0 +1,73 @@
+import { bollinger } from "../../src/indicators/bollinger";
+
+function makeCandle(date: string, close: number) {
+  return { date, open: close, high: close, low: close, close, volume: 0 };
+}
+
+describe("bollinger", () => {
+  // Period 5, stddev 2, constant close → bands collapse to middle
+  const constantData = [10, 10, 10, 10, 10].map((c, i) =>
+    makeCandle(`2024-01-0${i + 1}`, c)
+  );
+
+  it("returns same length as input", () => {
+    const result = bollinger(constantData, { period: 5 });
+    expect(result).toHaveLength(5);
+  });
+
+  it("first period-1 entries are nulls", () => {
+    const result = bollinger(constantData, { period: 5 });
+    for (let i = 0; i < 4; i++) {
+      expect(result[i].upper).toBeNull();
+      expect(result[i].middle).toBeNull();
+      expect(result[i].lower).toBeNull();
+      expect(result[i].percentB).toBeNull();
+    }
+  });
+
+  it("constant data: upper = middle = lower, stddev = 0", () => {
+    const result = bollinger(constantData, { period: 5 });
+    const last = result[4];
+    expect(last.middle).toBeCloseTo(10);
+    expect(last.upper).toBeCloseTo(10);
+    expect(last.lower).toBeCloseTo(10);
+  });
+
+  it("known dataset: middle = mean, upper > middle > lower", () => {
+    // closes [2, 4, 6, 8, 10] period 5
+    // mean = 6, variance = ((2-6)^2 + (4-6)^2 + (6-6)^2 + (8-6)^2 + (10-6)^2) / 5
+    //      = (16+4+0+4+16)/5 = 8, stddev = sqrt(8) ≈ 2.828
+    const data = [2, 4, 6, 8, 10].map((c, i) =>
+      makeCandle(`2024-01-0${i + 1}`, c)
+    );
+    const result = bollinger(data, { period: 5, stddev: 2 });
+    const last = result[4];
+    expect(last.middle).toBeCloseTo(6);
+    expect(last.upper).toBeCloseTo(6 + 2 * Math.sqrt(8), 3);
+    expect(last.lower).toBeCloseTo(6 - 2 * Math.sqrt(8), 3);
+  });
+
+  it("percentB: value at upper → 1, at lower → 0, at middle → 0.5", () => {
+    const data = [2, 4, 6, 8, 10].map((c, i) =>
+      makeCandle(`2024-01-0${i + 1}`, c)
+    );
+    const result = bollinger(data, { period: 5, stddev: 2 });
+    // last close = 10, upper ≈ 6 + 5.66 = 11.66, lower ≈ 6 - 5.66 = 0.34
+    // percentB = (10 - 0.34) / (11.66 - 0.34) ≈ 0.853
+    expect(result[4].percentB as number).toBeGreaterThan(0.5);
+    expect(result[4].percentB as number).toBeLessThan(1);
+  });
+
+  it("preserves dates", () => {
+    const result = bollinger(constantData, { period: 5 });
+    expect(result[4].date).toBe("2024-01-05");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(bollinger([])).toEqual([]);
+  });
+
+  it("throws on period < 1", () => {
+    expect(() => bollinger(constantData, { period: 0 })).toThrow();
+  });
+});

--- a/__tests__/indicators/macd.test.ts
+++ b/__tests__/indicators/macd.test.ts
@@ -1,0 +1,68 @@
+import { macd } from "../../src/indicators/macd";
+
+function makeCandle(date: string, close: number) {
+  return { date, open: close, high: close, low: close, close, volume: 0 };
+}
+
+describe("macd", () => {
+  // Synthetic uptrend 35 candles cho fast=12, slow=26, signal=9 → cần >= slow + signal + buffer
+  const closes = [
+    22, 22.5, 23, 22.8, 23.2, 23.5, 24, 24.2, 24.5, 25,
+    25.5, 26, 26.3, 26.8, 27.1, 27.5, 28, 28.3, 28.7, 29,
+    29.5, 30, 30.2, 30.5, 31, 31.5, 32, 32.3, 32.8, 33.2,
+    33.5, 34, 34.2, 34.5, 35,
+  ];
+  const data = closes.map((c, i) => makeCandle(`2024-01-${String(i + 1).padStart(2, "0")}`, c));
+
+  it("returns same length as input", () => {
+    const result = macd(data);
+    expect(result).toHaveLength(data.length);
+  });
+
+  it("first slow-1 entries have null macd", () => {
+    const result = macd(data);
+    for (let i = 0; i < 25; i++) {
+      expect(result[i].macd).toBeNull();
+    }
+  });
+
+  it("macd line is positive for uptrend after slow period", () => {
+    const result = macd(data);
+    const last = result[result.length - 1];
+    expect(last.macd).not.toBeNull();
+    expect(last.macd as number).toBeGreaterThan(0);
+  });
+
+  it("signal line lags macd line", () => {
+    const result = macd(data);
+    const last = result[result.length - 1];
+    expect(last.signal).not.toBeNull();
+    expect(last.histogram).not.toBeNull();
+    expect(Math.abs(last.histogram as number)).toBeLessThanOrEqual(Math.abs(last.macd as number) * 2);
+  });
+
+  it("preserves dates", () => {
+    const result = macd(data);
+    expect(result[0].date).toBe("2024-01-01");
+    expect(result[result.length - 1].date).toBe(data[data.length - 1].date);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(macd([])).toEqual([]);
+  });
+
+  it("throws when fast >= slow", () => {
+    expect(() => macd(data, { fast: 26, slow: 12 })).toThrow();
+    expect(() => macd(data, { fast: 12, slow: 12 })).toThrow();
+  });
+
+  it("throws on period < 1", () => {
+    expect(() => macd(data, { fast: 0 })).toThrow();
+  });
+
+  it("accepts custom periods", () => {
+    const result = macd(data, { fast: 5, slow: 10, signal: 3 });
+    expect(result).toHaveLength(data.length);
+    expect(result[9].macd).not.toBeNull();
+  });
+});

--- a/__tests__/simple.test.ts
+++ b/__tests__/simple.test.ts
@@ -1,4 +1,4 @@
-import { stock, commodity } from "../src";
+import { stock, commodity, quickQuote, recentHistory, compareSymbols, topMovers } from "../src";
 
 describe("Simple API", () => {
   describe("stock", () => {
@@ -61,6 +61,39 @@ describe("Simple API", () => {
       const data = await commodity.exchange();
       expect(Array.isArray(data)).toBe(true);
       expect(data[0]).toHaveProperty("currencyCode");
+    }, 30000);
+  });
+
+  describe("easy-mode", () => {
+    it("quickQuote returns flat object with price + change", async () => {
+      const q = await quickQuote("VCB");
+      expect(q).not.toBeNull();
+      expect(q).toHaveProperty("symbol", "VCB");
+      expect(q).toHaveProperty("price");
+      expect(q).toHaveProperty("volume");
+    }, 30000);
+
+    it("recentHistory returns N most-recent candles", async () => {
+      const rows = await recentHistory("VCB", 10);
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows.length).toBeLessThanOrEqual(10);
+      if (rows.length > 0) expect(rows[0]).toHaveProperty("close");
+    }, 30000);
+
+    it("compareSymbols returns array of flat quote objects", async () => {
+      const rows = await compareSymbols(["VCB", "FPT"]);
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows.length).toBe(2);
+      expect(rows[0]).toHaveProperty("symbol");
+      expect(rows[0]).toHaveProperty("price");
+    }, 30000);
+
+    it("topMovers returns { gainers, losers }", async () => {
+      const data = await topMovers();
+      expect(data).toHaveProperty("gainers");
+      expect(data).toHaveProperty("losers");
+      expect(Array.isArray(data.gainers)).toBe(true);
+      expect(Array.isArray(data.losers)).toBe(true);
     }, 30000);
   });
 });

--- a/__tests__/watchlist.test.ts
+++ b/__tests__/watchlist.test.ts
@@ -1,0 +1,97 @@
+import { Watchlist } from "../src/watchlist";
+import { WatchlistStorage } from "../src/watchlist/storage";
+
+class MemoryStorage implements WatchlistStorage {
+  private data: string | null = null;
+  async read() {
+    return this.data;
+  }
+  async write(json: string) {
+    this.data = json;
+  }
+  inspect() {
+    return this.data;
+  }
+}
+
+describe("Watchlist", () => {
+  let storage: MemoryStorage;
+  let wl: Watchlist;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    wl = new Watchlist(storage);
+  });
+
+  it("create + has + listAll", async () => {
+    await wl.create("banks");
+    expect(await wl.has("banks")).toBe(true);
+    expect(await wl.listAll()).toEqual(["banks"]);
+  });
+
+  it("add string symbol uppercases", async () => {
+    await wl.create("banks");
+    await wl.add("banks", "vcb");
+    expect(await wl.list("banks")).toEqual(["VCB"]);
+  });
+
+  it("add array of symbols", async () => {
+    await wl.add("tech", ["FPT", "CMG"]);
+    expect(await wl.list("tech")).toEqual(["FPT", "CMG"]);
+  });
+
+  it("add creates watchlist implicitly", async () => {
+    await wl.add("misc", "VCB");
+    expect(await wl.has("misc")).toBe(true);
+    expect(await wl.list("misc")).toEqual(["VCB"]);
+  });
+
+  it("dedup on add", async () => {
+    await wl.add("banks", ["VCB", "TCB"]);
+    await wl.add("banks", "VCB");
+    await wl.add("banks", "vcb");
+    expect(await wl.list("banks")).toEqual(["VCB", "TCB"]);
+  });
+
+  it("remove symbol", async () => {
+    await wl.add("banks", ["VCB", "TCB", "MBB"]);
+    await wl.remove("banks", "TCB");
+    expect(await wl.list("banks")).toEqual(["VCB", "MBB"]);
+  });
+
+  it("delete watchlist", async () => {
+    await wl.add("temp", "VCB");
+    await wl.delete("temp");
+    expect(await wl.has("temp")).toBe(false);
+    expect(await wl.list("temp")).toEqual([]);
+  });
+
+  it("list returns empty for missing watchlist", async () => {
+    expect(await wl.list("nonexistent")).toEqual([]);
+  });
+
+  it("persists across instances via same storage", async () => {
+    await wl.add("banks", ["VCB", "TCB"]);
+    const wl2 = new Watchlist(storage);
+    expect(await wl2.list("banks")).toEqual(["VCB", "TCB"]);
+  });
+
+  it("setStorage swaps backend", async () => {
+    await wl.add("a", "VCB");
+    const other = new MemoryStorage();
+    wl.setStorage(other);
+    expect(await wl.list("a")).toEqual([]);
+  });
+
+  it("invalid JSON in storage → graceful fallback", async () => {
+    await storage.write("not-json{{{");
+    const wl3 = new Watchlist(storage);
+    expect(await wl3.listAll()).toEqual([]);
+    await wl3.add("recovery", "VCB");
+    expect(await wl3.list("recovery")).toEqual(["VCB"]);
+  });
+
+  it("throws on empty name in create", async () => {
+    await expect(wl.create("")).rejects.toThrow();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vnstock-js",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
@@ -64,6 +64,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.8.4",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",

--- a/src/cli/commands/quote.ts
+++ b/src/cli/commands/quote.ts
@@ -15,23 +15,27 @@ export interface QuoteOpts {
   verbose: boolean;
 }
 
-export async function handleQuote(opts: QuoteOpts): Promise<string> {
-  var symbol = opts.symbol.toUpperCase();
-  var result = await vnstock.stock.trading.priceBoard([symbol]);
-  if (!result || result.length === 0) {
-    throw new Error("Symbol not found: " + symbol);
-  }
-  var pb = result[0];
+function timestampNow(): string {
+  var now = new Date();
+  var pad = function (n: number) { return n < 10 ? "0" + n : String(n); };
+  return (
+    now.getFullYear() + "-" + pad(now.getMonth() + 1) + "-" + pad(now.getDate()) +
+    " " + pad(now.getHours()) + ":" + pad(now.getMinutes())
+  );
+}
 
-  if (opts.json) return renderJson(pb);
-  if (opts.csv) return renderCsv([pb as any]);
-
+function renderOneQuote(pb: any, ts: string, opts: QuoteOpts): string {
   var change = pb.price - pb.referencePrice;
   var changePct = pb.referencePrice > 0 ? (change / pb.referencePrice) * 100 : 0;
   var priceStr = priceColor(change, formatPrice(pb.price), opts);
   var pctStr = priceColor(change, formatPercent(changePct), opts);
 
-  var line1 = bold(pb.symbol, opts) + "  " + pb.companyName + dim(" · " + pb.exchange, opts);
+  var line1 =
+    bold(pb.symbol, opts) +
+    "  " +
+    pb.companyName +
+    dim(" · " + pb.exchange, opts) +
+    dim("  · " + ts, opts);
   var parts: string[] = [];
   parts.push(priceStr);
   parts.push(pctStr);
@@ -52,4 +56,27 @@ export async function handleQuote(opts: QuoteOpts): Promise<string> {
     "/" +
     compactNumber(pb.foreignSellVolume);
   return line1 + "\n" + line2 + "\n" + line3;
+}
+
+export async function handleQuote(opts: QuoteOpts): Promise<string> {
+  var symbols = opts.symbol
+    .split(",")
+    .map(function (s) { return s.trim().toUpperCase(); })
+    .filter(function (s) { return s.length > 0; });
+
+  if (symbols.length === 0) {
+    throw new Error("No symbol provided");
+  }
+
+  var result = await vnstock.stock.trading.priceBoard(symbols);
+  if (!result || result.length === 0) {
+    throw new Error("Symbol(s) not found: " + symbols.join(","));
+  }
+
+  if (opts.json) return renderJson(symbols.length === 1 ? result[0] : result);
+  if (opts.csv) return renderCsv(result as any[]);
+
+  var ts = timestampNow();
+  var blocks = result.map(function (pb: any) { return renderOneQuote(pb, ts, opts); });
+  return blocks.join("\n\n");
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -220,11 +220,34 @@ function buildProgram(): Command {
       );
     });
 
+  program
+    .command("mcp")
+    .description("Start MCP server (stdio) for Claude Desktop / Cursor / VS Code")
+    .action(async function () {
+      var mod = await import("./mcp/index");
+      await mod.start();
+    });
+
   return program;
 }
 
+// Default-to-quote shortcut: `vnstock MBB` → `vnstock quote MBB`.
+// If first positional looks like a symbol (uppercase letters/digits/comma)
+// and not a known subcommand or flag, inject `quote`.
+var KNOWN_COMMANDS = ["quote", "history", "search", "symbols", "mcp", "help"];
+var argv = process.argv.slice();
+if (argv.length >= 3) {
+  var first = argv[2];
+  var isKnown = KNOWN_COMMANDS.indexOf(first) !== -1;
+  var isFlag = first.charAt(0) === "-";
+  var looksLikeSymbols = /^[A-Za-z][A-Za-z0-9,]*$/.test(first);
+  if (!isKnown && !isFlag && looksLikeSymbols) {
+    argv.splice(2, 0, "quote");
+  }
+}
+
 var program = buildProgram();
-program.parseAsync(process.argv).catch(function (err: any) {
+program.parseAsync(argv).catch(function (err: any) {
   process.stderr.write("Fatal: " + (err && err.message) + "\n");
   process.exit(2);
 });

--- a/src/cli/mcp/cache.ts
+++ b/src/cli/mcp/cache.ts
@@ -1,0 +1,34 @@
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+export class TTLCache<T> {
+  private store = new Map<string, CacheEntry<T>>();
+  private ttlMs: number;
+
+  constructor(ttlMs: number) {
+    this.ttlMs = ttlMs;
+  }
+
+  get(key: string): T | undefined {
+    var hit = this.store.get(key);
+    if (!hit) return undefined;
+    if (Date.now() > hit.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return hit.data;
+  }
+
+  set(key: string, data: T): void {
+    this.store.set(key, { data, expiresAt: Date.now() + this.ttlMs });
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+export const QUOTE_TTL_MS = 30_000;
+export const AI_CONTEXT_TTL_MS = 60_000;

--- a/src/cli/mcp/formatters.ts
+++ b/src/cli/mcp/formatters.ts
@@ -1,0 +1,24 @@
+export interface McpContent {
+  type: "text";
+  text: string;
+}
+
+export interface McpToolResponse {
+  content: McpContent[];
+  isError?: boolean;
+}
+
+export function textResponse(summary: string, structured?: unknown): McpToolResponse {
+  var content: McpContent[] = [{ type: "text", text: summary }];
+  if (structured !== undefined) {
+    content.push({ type: "text", text: JSON.stringify(structured, null, 2) });
+  }
+  return { content };
+}
+
+export function errorResponse(message: string): McpToolResponse {
+  return {
+    content: [{ type: "text", text: message }],
+    isError: true,
+  };
+}

--- a/src/cli/mcp/handlers.ts
+++ b/src/cli/mcp/handlers.ts
@@ -1,0 +1,224 @@
+import { Vnstock } from "../../runtime";
+import { init } from "../../data";
+import { Directory } from "../../core/listing/directory";
+import { calendar } from "../../core/market";
+import { textResponse, errorResponse, McpToolResponse } from "./formatters";
+import { TTLCache, QUOTE_TTL_MS, AI_CONTEXT_TTL_MS } from "./cache";
+
+var initialized = false;
+async function ensureData() {
+  if (initialized) return;
+  await init();
+  initialized = true;
+}
+
+const vnstock = new Vnstock();
+const quoteCache = new TTLCache<any>(QUOTE_TTL_MS);
+const aiCache = new TTLCache<any>(AI_CONTEXT_TTL_MS);
+
+function todayISO(): string {
+  return new Date().toISOString().substring(0, 10);
+}
+
+function daysAgoISO(days: number): string {
+  var d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().substring(0, 10);
+}
+
+export async function handleGetQuote(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  var cached = quoteCache.get(symbol);
+  if (cached) return formatQuote(symbol, cached);
+  try {
+    var list = await vnstock.stock.trading.priceBoard([symbol]);
+    if (list.length === 0) {
+      return errorResponse(`Không tìm thấy mã "${symbol}". Hãy thử search_symbols với tên công ty.`);
+    }
+    quoteCache.set(symbol, list[0]);
+    return formatQuote(symbol, list[0]);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi lấy giá ${symbol}: ${e.message || e}`);
+  }
+}
+
+function formatQuote(symbol: string, pb: any): McpToolResponse {
+  var change = pb.percentPriceChange != null ? (pb.percentPriceChange * 100).toFixed(2) + "%" : "n/a";
+  var sign = pb.percentPriceChange > 0 ? "+" : "";
+  var summary = `${symbol} ${pb.companyName || ""}\n` +
+    `Giá: ${pb.price}k  (${sign}${change})  KL: ${pb.totalVolume?.toLocaleString() || 0}\n` +
+    `Trần/Sàn: ${pb.ceilingPrice}k / ${pb.floorPrice}k  Tham chiếu: ${pb.referencePrice}k`;
+  return textResponse(summary, pb);
+}
+
+export async function handleGetHistory(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  var from = args.from || daysAgoISO(30);
+  var to = args.to || todayISO();
+  var limit = typeof args.limit === "number" ? args.limit : 30;
+  try {
+    var rows = await vnstock.stock.quote.history({
+      symbols: [symbol],
+      start: from,
+      end: to,
+      timeFrame: "1D",
+    });
+    var sliced = rows.slice(-limit);
+    var summary = `${symbol} từ ${from} đến ${to} — ${sliced.length} phiên`;
+    return textResponse(summary, sliced);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi lấy lịch sử ${symbol}: ${e.message || e}`);
+  }
+}
+
+export async function handleSearchSymbols(args: any): Promise<McpToolResponse> {
+  var query = String(args.query || "").trim();
+  if (!query) return errorResponse("Thiếu tham số 'query'.");
+  var limit = typeof args.limit === "number" ? args.limit : 10;
+  try {
+    await ensureData();
+    var results = Directory.search(query, { limit });
+    var summary = `Tìm thấy ${results.length} kết quả cho "${query}"`;
+    return textResponse(summary, results);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi tìm kiếm: ${e.message || e}`);
+  }
+}
+
+export async function handleListSymbols(args: any): Promise<McpToolResponse> {
+  var exchange = args.exchange ? String(args.exchange).toUpperCase() : null;
+  var limit = typeof args.limit === "number" ? args.limit : undefined;
+  try {
+    await ensureData();
+    var list = exchange ? Directory.getByExchange(exchange) : Directory.search("", { limit: 10000 });
+    if (limit) list = list.slice(0, limit);
+    var summary = exchange
+      ? `Sàn ${exchange}: ${list.length} mã`
+      : `Tổng: ${list.length} mã`;
+    return textResponse(summary, list);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi liệt kê mã: ${e.message || e}`);
+  }
+}
+
+export async function handleTopMovers(args: any): Promise<McpToolResponse> {
+  var limit = typeof args.limit === "number" ? args.limit : 10;
+  try {
+    var pair = await Promise.all([
+      vnstock.stock.trading.topGainers(),
+      vnstock.stock.trading.topLosers(),
+    ]);
+    var gainers = pair[0].slice(0, limit);
+    var losers = pair[1].slice(0, limit);
+    var summary = `Top ${limit} tăng + ${limit} giảm hôm nay`;
+    return textResponse(summary, { gainers, losers });
+  } catch (e: any) {
+    return errorResponse(`Lỗi: ${e.message || e}`);
+  }
+}
+
+export async function handleIsTradeDay(args: any): Promise<McpToolResponse> {
+  var date = args.date || todayISO();
+  try {
+    await ensureData();
+    var isTrade = calendar.isTradeDay(date);
+    return textResponse(
+      `Ngày ${date}: ${isTrade ? "có giao dịch" : "không có giao dịch (nghỉ lễ hoặc cuối tuần)"}`,
+      { date, isTradeDay: isTrade }
+    );
+  } catch (e: any) {
+    return errorResponse(`Lỗi: ${e.message || e}`);
+  }
+}
+
+export async function handleGetTradingCalendar(args: any): Promise<McpToolResponse> {
+  var year = Number(args.year);
+  if (!year || year < 1900) return errorResponse("Thiếu hoặc invalid 'year'.");
+  try {
+    await ensureData();
+    var holidays = calendar.holidays(year);
+    return textResponse(
+      `Năm ${year}: ${holidays.length} ngày nghỉ lễ TTCK`,
+      { year, holidays }
+    );
+  } catch (e: any) {
+    return errorResponse(`Lỗi: ${e.message || e}`);
+  }
+}
+
+export async function handleGetCompanyInfo(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  try {
+    await ensureData();
+    var info = Directory.getBySymbol(symbol);
+    if (!info) {
+      return errorResponse(`Không tìm thấy mã "${symbol}". Hãy thử search_symbols.`);
+    }
+    var summary = `${symbol} — ${info.companyName} · ${info.exchange}`;
+    return textResponse(summary, info);
+  } catch (e: any) {
+    return errorResponse(`Lỗi: ${e.message || e}`);
+  }
+}
+
+export async function handleGetAIContext(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  var lookback = typeof args.lookback === "number" ? args.lookback : 200;
+  var key = symbol + "|" + lookback;
+  var cached = aiCache.get(key);
+  if (cached) {
+    return textResponse(`AI context cho ${symbol} (cached)`, cached);
+  }
+  try {
+    var ctx = await vnstock.stock.aiContext(symbol, { lookback });
+    aiCache.set(key, ctx);
+    var summary = `${symbol} — trend ${ctx.trend.direction} (${(ctx.trend.strength * 100).toFixed(0)}%)`;
+    return textResponse(summary, ctx);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi build AI context ${symbol}: ${e.message || e}`);
+  }
+}
+
+export async function handleToAIPrompt(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  var lang: "vi" | "en" = args.lang === "en" ? "en" : "vi";
+  try {
+    var text = await vnstock.stock.toAIPrompt(symbol, { lang });
+    return textResponse(text);
+  } catch (e: any) {
+    return errorResponse(`Lỗi: ${e.message || e}`);
+  }
+}
+
+export async function handleCompareSymbols(args: any): Promise<McpToolResponse> {
+  var symbols = Array.isArray(args.symbols) ? args.symbols : [];
+  if (symbols.length < 2) return errorResponse("Cần ≥2 mã để so sánh.");
+  if (symbols.length > 10) return errorResponse("Tối đa 10 mã.");
+  try {
+    var upperSymbols = symbols.map((s: any) => String(s).toUpperCase());
+    var list = await vnstock.stock.trading.priceBoard(upperSymbols);
+    var summary = `So sánh ${list.length} mã: ${upperSymbols.join(", ")}`;
+    return textResponse(summary, list);
+  } catch (e: any) {
+    return errorResponse(`Lỗi: ${e.message || e}`);
+  }
+}
+
+export const handlers: Record<string, (args: any) => Promise<McpToolResponse>> = {
+  get_quote: handleGetQuote,
+  get_history: handleGetHistory,
+  search_symbols: handleSearchSymbols,
+  list_symbols: handleListSymbols,
+  top_movers: handleTopMovers,
+  is_trade_day: handleIsTradeDay,
+  get_trading_calendar: handleGetTradingCalendar,
+  get_company_info: handleGetCompanyInfo,
+  get_ai_context: handleGetAIContext,
+  to_ai_prompt: handleToAIPrompt,
+  compare_symbols: handleCompareSymbols,
+};

--- a/src/cli/mcp/index.ts
+++ b/src/cli/mcp/index.ts
@@ -1,0 +1,49 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { tools } from "./tools";
+import { handlers } from "./handlers";
+import { errorResponse } from "./formatters";
+
+export async function start(): Promise<void> {
+  const pkg = require("../../../package.json");
+
+  const server = new Server(
+    {
+      name: "vnstock-js",
+      version: pkg.version,
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request): Promise<any> => {
+    const { name, arguments: args } = request.params;
+    const handler = handlers[name];
+    if (!handler) {
+      return errorResponse(`Tool không tồn tại: ${name}`);
+    }
+    try {
+      return await handler(args || {});
+    } catch (e: any) {
+      return errorResponse(`Lỗi nội bộ tool ${name}: ${e.message || e}`);
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  process.stderr.write(
+    `[vnstock-js mcp] Server started (v${pkg.version}), ${tools.length} tools registered.\n`
+  );
+}

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -1,0 +1,170 @@
+export interface ToolSchema {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<string, any>;
+    required?: string[];
+  };
+}
+
+export const tools: ToolSchema[] = [
+  {
+    name: "get_quote",
+    description:
+      "Lấy giá cổ phiếu Việt Nam hiện tại (snapshot). Trả về giá khớp, % thay đổi, khối lượng, giá trần/sàn/tham chiếu. " +
+      "Dùng khi user hỏi 'giá VCB hôm nay', 'FPT bao nhiêu', 'cổ phiếu X tăng hay giảm'. " +
+      "EN: Get current Vietnam stock quote. Returns matched price, change%, volume, ceiling/floor/reference prices.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu (3-4 chữ cái, VD: VCB, FPT, VNM)" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
+    name: "get_history",
+    description:
+      "Lấy lịch sử giá OHLCV của 1 mã. Hỗ trợ relative date (7d/1w/1m/1y) hoặc absolute (YYYY-MM-DD). " +
+      "Dùng khi user hỏi 'giá VCB 7 ngày qua', 'lịch sử FPT tháng trước'. " +
+      "EN: Get OHLCV price history for a Vietnam stock symbol.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu" },
+        from: { type: "string", description: "YYYY-MM-DD ngày bắt đầu (mặc định: 30 ngày trước)" },
+        to: { type: "string", description: "YYYY-MM-DD ngày kết thúc (mặc định: hôm nay)" },
+        limit: { type: "number", description: "Số phiên tối đa trả về (mặc định 30)" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
+    name: "search_symbols",
+    description:
+      "Tìm mã cổ phiếu theo tên hoặc ticker (fuzzy). Dùng khi user hỏi 'mã của Vinamilk', 'các ngân hàng niêm yết'. " +
+      "EN: Search Vietnam stock symbols by name or ticker. Fuzzy, relevance-ranked.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Tên công ty hoặc ticker" },
+        limit: { type: "number", description: "Kết quả tối đa (mặc định 10)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "list_symbols",
+    description:
+      "Liệt kê mã cổ phiếu theo sàn. Dùng khi user hỏi 'có bao nhiêu mã trên HOSE', 'liệt kê mã HNX'. " +
+      "EN: List Vietnam stock symbols by exchange.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        exchange: { type: "string", description: "HOSE/HSX, HNX, hoặc UPCOM (bỏ qua = toàn bộ)" },
+        limit: { type: "number", description: "Số mã tối đa" },
+      },
+    },
+  },
+  {
+    name: "top_movers",
+    description:
+      "Lấy mã tăng mạnh và giảm mạnh hôm nay. Trả về cả gainers và losers. " +
+      "EN: Get today's top gainers and losers on Vietnam market.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number", description: "Số mã mỗi bên (mặc định 10)" },
+      },
+    },
+  },
+  {
+    name: "is_trade_day",
+    description:
+      "Kiểm tra 1 ngày có phải ngày giao dịch của TTCK VN không (loại trừ thứ 7/CN và ngày nghỉ lễ). " +
+      "EN: Check if a date is a Vietnam stock market trading day.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        date: { type: "string", description: "YYYY-MM-DD (mặc định hôm nay)" },
+      },
+    },
+  },
+  {
+    name: "get_trading_calendar",
+    description:
+      "Lấy danh sách ngày nghỉ lễ TTCK VN trong năm. " +
+      "EN: Get Vietnam stock market holiday schedule for a year.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        year: { type: "number", description: "Năm 4 chữ số (VD: 2026)" },
+      },
+      required: ["year"],
+    },
+  },
+  {
+    name: "get_company_info",
+    description:
+      "Lấy thông tin công ty: tên đầy đủ, sàn niêm yết, ngành. " +
+      "EN: Get Vietnam company profile: name, exchange, industry.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
+    name: "get_ai_context",
+    description:
+      "Lấy bối cảnh phân tích kỹ thuật cho 1 mã, dạng structured JSON. " +
+      "Bao gồm trend (bullish/bearish/neutral), indicators (RSI, MACD, SMA20/50/200, ATR, Bollinger), " +
+      "support/resistance pivot, volume signal, %change 1d/7d/30d/90d. " +
+      "Dùng khi user hỏi 'phân tích kỹ thuật VCB', 'VCB đang xu hướng gì'. " +
+      "EN: Get pre-computed technical analysis context for a Vietnam stock symbol.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu" },
+        lookback: { type: "number", description: "Số phiên lịch sử (mặc định 200)" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
+    name: "to_ai_prompt",
+    description:
+      "Tương tự get_ai_context nhưng trả plain-text format optimize cho LLM context window. " +
+      "Dùng khi user export context để dán vào GPT/Gemini bên ngoài. " +
+      "EN: Same as get_ai_context but returns plain-text formatted for LLM context window.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu" },
+        lang: { type: "string", description: "vi (mặc định) hoặc en" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
+    name: "compare_symbols",
+    description:
+      "So sánh nhiều mã cùng lúc: giá, % change, RSI, volume signal. " +
+      "Dùng khi user hỏi 'so sánh VCB và TCB', '3 ngân hàng top'. " +
+      "EN: Compare multiple Vietnam stocks side-by-side: price, change%, RSI, volume signal.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbols: {
+          type: "array",
+          items: { type: "string" },
+          description: "Mảng mã cổ phiếu (2-10)",
+        },
+      },
+      required: ["symbols"],
+    },
+  },
+];

--- a/src/core/stock/ai-context.ts
+++ b/src/core/stock/ai-context.ts
@@ -1,0 +1,266 @@
+import { QuoteHistory } from "../../models/normalized";
+import { StockDataAdapter } from "../../adapters/types";
+import { sma } from "../../indicators/sma";
+import { ema } from "../../indicators/ema";
+import { rsi } from "../../indicators/rsi";
+import { macd } from "../../indicators/macd";
+import { bollinger } from "../../indicators/bollinger";
+import { atr } from "../../indicators/atr";
+import { detectPivots, PivotLevels } from "./pivot";
+
+export interface TrendInfo {
+  direction: "bullish" | "bearish" | "neutral";
+  strength: number;
+  rationale: string;
+}
+
+export interface IndicatorSnapshot {
+  rsi14: number | null;
+  macd: { line: number | null; signal: number | null; histogram: number | null; crossover: "bullish" | "bearish" | "none" };
+  sma: { 20: number | null; 50: number | null; 200: number | null };
+  ema: { 20: number | null; 50: number | null; 200: number | null };
+  bollinger: { upper: number | null; middle: number | null; lower: number | null; percentB: number | null };
+  atr14: number | null;
+}
+
+export interface VolumeInfo {
+  today: number;
+  avg20: number;
+  signal: "above_average" | "below_average" | "normal";
+  zscore: number;
+}
+
+export interface PerformanceInfo {
+  change1d: number | null;
+  change7d: number | null;
+  change30d: number | null;
+  change90d: number | null;
+}
+
+export interface AIContext {
+  symbol: string;
+  asOf: string;
+  trend: TrendInfo;
+  indicators: IndicatorSnapshot;
+  levels: PivotLevels;
+  volume: VolumeInfo;
+  performance: PerformanceInfo;
+}
+
+function lastValue<T extends { ema?: number | null; sma?: number | null; rsi?: number | null }>(
+  series: T[],
+  key: "ema" | "sma" | "rsi"
+): number | null {
+  if (series.length === 0) return null;
+  const v = (series[series.length - 1] as any)[key];
+  return v === undefined ? null : v;
+}
+
+function computeSlope(values: (number | null)[]): number {
+  const clean = values.filter((v) => v !== null) as number[];
+  if (clean.length < 2) return 0;
+  const n = clean.length;
+  let sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
+  for (let i = 0; i < n; i++) {
+    sumX += i;
+    sumY += clean[i];
+    sumXY += i * clean[i];
+    sumXX += i * i;
+  }
+  const denom = n * sumXX - sumX * sumX;
+  if (denom === 0) return 0;
+  return (n * sumXY - sumX * sumY) / denom;
+}
+
+export function classifyTrend(data: QuoteHistory[]): TrendInfo {
+  if (data.length < 50) {
+    return { direction: "neutral", strength: 0, rationale: "Không đủ dữ liệu (cần ≥50 phiên)" };
+  }
+
+  const ema20Series = ema(data, { period: 20 });
+  const ema50Series = ema(data, { period: 50 });
+  const ema200Series = data.length >= 200 ? ema(data, { period: 200 }) : null;
+
+  const e20 = lastValue(ema20Series, "ema");
+  const e50 = lastValue(ema50Series, "ema");
+  const e200 = ema200Series ? lastValue(ema200Series, "ema") : null;
+
+  const recent20 = ema20Series.slice(-5).map((p) => p.ema);
+  const slope = computeSlope(recent20);
+
+  if (e20 === null || e50 === null) {
+    return { direction: "neutral", strength: 0, rationale: "Không đủ dữ liệu indicator" };
+  }
+
+  let direction: "bullish" | "bearish" | "neutral";
+  let rationale: string;
+  let strength = 0;
+
+  if (e20 > e50 && (e200 === null || e50 > e200) && slope > 0) {
+    direction = "bullish";
+    rationale = "EMA20 > EMA50" + (e200 !== null ? " > EMA200" : "") + ", slope EMA20 dương 5 phiên";
+    strength = Math.min(1, Math.abs(slope) * 10);
+  } else if (e20 < e50 && (e200 === null || e50 < e200) && slope < 0) {
+    direction = "bearish";
+    rationale = "EMA20 < EMA50" + (e200 !== null ? " < EMA200" : "") + ", slope EMA20 âm 5 phiên";
+    strength = Math.min(1, Math.abs(slope) * 10);
+  } else {
+    direction = "neutral";
+    rationale = "EMA chuỗi không nhất quán hoặc slope flat — sideway";
+    strength = 0.3;
+  }
+
+  return { direction, strength, rationale };
+}
+
+export function snapshotIndicators(data: QuoteHistory[]): IndicatorSnapshot {
+  const rsiSeries = rsi(data, { period: 14 });
+  const macdSeries = macd(data);
+  const sma20 = data.length >= 20 ? lastValue(sma(data, { period: 20 }), "sma") : null;
+  const sma50 = data.length >= 50 ? lastValue(sma(data, { period: 50 }), "sma") : null;
+  const sma200 = data.length >= 200 ? lastValue(sma(data, { period: 200 }), "sma") : null;
+  const ema20 = data.length >= 20 ? lastValue(ema(data, { period: 20 }), "ema") : null;
+  const ema50 = data.length >= 50 ? lastValue(ema(data, { period: 50 }), "ema") : null;
+  const ema200 = data.length >= 200 ? lastValue(ema(data, { period: 200 }), "ema") : null;
+  const bollSeries = bollinger(data, { period: 20 });
+  const atrSeries = atr(data, 14);
+
+  const lastRsi = rsiSeries.length > 0 ? rsiSeries[rsiSeries.length - 1].rsi : null;
+  const lastMacd = macdSeries.length > 0 ? macdSeries[macdSeries.length - 1] : null;
+  const prevMacd = macdSeries.length > 1 ? macdSeries[macdSeries.length - 2] : null;
+  const lastBoll = bollSeries.length > 0 ? bollSeries[bollSeries.length - 1] : null;
+  const lastAtr = atrSeries.length > 0 ? atrSeries[atrSeries.length - 1].atr : null;
+
+  let crossover: "bullish" | "bearish" | "none" = "none";
+  if (lastMacd && prevMacd && lastMacd.histogram !== null && prevMacd.histogram !== null) {
+    if (prevMacd.histogram <= 0 && lastMacd.histogram > 0) crossover = "bullish";
+    else if (prevMacd.histogram >= 0 && lastMacd.histogram < 0) crossover = "bearish";
+  }
+
+  return {
+    rsi14: lastRsi,
+    macd: {
+      line: lastMacd?.macd ?? null,
+      signal: lastMacd?.signal ?? null,
+      histogram: lastMacd?.histogram ?? null,
+      crossover,
+    },
+    sma: { 20: sma20, 50: sma50, 200: sma200 },
+    ema: { 20: ema20, 50: ema50, 200: ema200 },
+    bollinger: {
+      upper: lastBoll?.upper ?? null,
+      middle: lastBoll?.middle ?? null,
+      lower: lastBoll?.lower ?? null,
+      percentB: lastBoll?.percentB ?? null,
+    },
+    atr14: lastAtr,
+  };
+}
+
+export function classifyVolume(data: QuoteHistory[]): VolumeInfo {
+  if (data.length < 21) {
+    const last = data[data.length - 1];
+    return { today: last?.volume ?? 0, avg20: 0, signal: "normal", zscore: 0 };
+  }
+  const volumes = data.map((c) => c.volume);
+  const today = volumes[volumes.length - 1];
+  const prev20 = volumes.slice(-21, -1);
+  const mean = prev20.reduce((a, b) => a + b, 0) / 20;
+  let variance = 0;
+  for (const v of prev20) variance += (v - mean) * (v - mean);
+  const sd = Math.sqrt(variance / 20);
+  let zscore: number;
+  let signal: "above_average" | "below_average" | "normal";
+  if (sd > 0) {
+    zscore = (today - mean) / sd;
+    signal = zscore > 2 ? "above_average" : zscore < -1 ? "below_average" : "normal";
+  } else {
+    // Constant historical volume — fall back to ratio comparison
+    zscore = mean > 0 ? (today - mean) / mean : 0;
+    if (mean === 0) signal = "normal";
+    else if (today >= mean * 2) signal = "above_average";
+    else if (today <= mean * 0.5) signal = "below_average";
+    else signal = "normal";
+  }
+  return { today, avg20: mean, signal, zscore };
+}
+
+export function computePerformance(data: QuoteHistory[]): PerformanceInfo {
+  if (data.length === 0) return { change1d: null, change7d: null, change30d: null, change90d: null };
+  const last = data[data.length - 1].close;
+  function chg(daysBack: number): number | null {
+    const idx = data.length - 1 - daysBack;
+    if (idx < 0) return null;
+    const ref = data[idx].close;
+    return ref > 0 ? (last - ref) / ref : null;
+  }
+  return { change1d: chg(1), change7d: chg(7), change30d: chg(30), change90d: chg(90) };
+}
+
+export async function buildAIContext(
+  adapter: StockDataAdapter,
+  symbol: string,
+  options: { lookback?: number } = {}
+): Promise<AIContext> {
+  const lookback = options.lookback ?? 200;
+  const today = new Date();
+  const start = new Date(today);
+  start.setDate(start.getDate() - Math.ceil(lookback * 1.5) - 30);
+  const startStr = start.toISOString().substring(0, 10);
+
+  const candles = await adapter.fetchQuoteHistory({
+    symbols: [symbol],
+    start: startStr,
+    timeFrame: "1D",
+    countBack: lookback + 30,
+  });
+
+  const sliced = candles.slice(-lookback);
+
+  return {
+    symbol,
+    asOf: sliced.length > 0 ? sliced[sliced.length - 1].date : "",
+    trend: classifyTrend(sliced),
+    indicators: snapshotIndicators(sliced),
+    levels: detectPivots(sliced, { window: 5, topN: 3 }),
+    volume: classifyVolume(sliced),
+    performance: computePerformance(sliced),
+  };
+}
+
+export function formatAIPrompt(ctx: AIContext, lang: "vi" | "en" = "vi"): string {
+  const lines: string[] = [];
+  if (lang === "vi") {
+    lines.push(`=== ${ctx.symbol} — ${ctx.asOf} ===`);
+    lines.push(`Trend: ${ctx.trend.direction} (strength ${(ctx.trend.strength * 100).toFixed(0)}%) — ${ctx.trend.rationale}`);
+    const ind = ctx.indicators;
+    lines.push(`RSI(14): ${ind.rsi14?.toFixed(1) ?? "n/a"}`);
+    lines.push(`MACD: line ${ind.macd.line?.toFixed(3) ?? "n/a"}, signal ${ind.macd.signal?.toFixed(3) ?? "n/a"}, histogram ${ind.macd.histogram?.toFixed(3) ?? "n/a"}, crossover: ${ind.macd.crossover}`);
+    lines.push(`SMA: 20=${ind.sma[20]?.toFixed(2) ?? "n/a"}, 50=${ind.sma[50]?.toFixed(2) ?? "n/a"}, 200=${ind.sma[200]?.toFixed(2) ?? "n/a"}`);
+    lines.push(`EMA: 20=${ind.ema[20]?.toFixed(2) ?? "n/a"}, 50=${ind.ema[50]?.toFixed(2) ?? "n/a"}, 200=${ind.ema[200]?.toFixed(2) ?? "n/a"}`);
+    lines.push(`Bollinger %B: ${ind.bollinger.percentB?.toFixed(2) ?? "n/a"} (upper=${ind.bollinger.upper?.toFixed(2) ?? "n/a"}, lower=${ind.bollinger.lower?.toFixed(2) ?? "n/a"})`);
+    lines.push(`ATR(14): ${ind.atr14?.toFixed(3) ?? "n/a"}`);
+    lines.push(`Volume: ${ctx.volume.today.toLocaleString()} (avg ${ctx.volume.avg20.toLocaleString()}, z-score ${ctx.volume.zscore.toFixed(2)}, ${ctx.volume.signal})`);
+    lines.push(`Support: ${ctx.levels.support.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
+    lines.push(`Resistance: ${ctx.levels.resistance.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
+    const perf = ctx.performance;
+    const fmtPct = (v: number | null) => (v === null ? "n/a" : (v >= 0 ? "+" : "") + (v * 100).toFixed(2) + "%");
+    lines.push(`Change: 1d ${fmtPct(perf.change1d)} · 7d ${fmtPct(perf.change7d)} · 30d ${fmtPct(perf.change30d)} · 90d ${fmtPct(perf.change90d)}`);
+  } else {
+    lines.push(`=== ${ctx.symbol} — ${ctx.asOf} ===`);
+    lines.push(`Trend: ${ctx.trend.direction} (strength ${(ctx.trend.strength * 100).toFixed(0)}%) — ${ctx.trend.rationale}`);
+    const ind = ctx.indicators;
+    lines.push(`RSI(14): ${ind.rsi14?.toFixed(1) ?? "n/a"}`);
+    lines.push(`MACD: line ${ind.macd.line?.toFixed(3) ?? "n/a"}, signal ${ind.macd.signal?.toFixed(3) ?? "n/a"}, crossover: ${ind.macd.crossover}`);
+    lines.push(`SMA: 20=${ind.sma[20]?.toFixed(2) ?? "n/a"}, 50=${ind.sma[50]?.toFixed(2) ?? "n/a"}, 200=${ind.sma[200]?.toFixed(2) ?? "n/a"}`);
+    lines.push(`Bollinger %B: ${ind.bollinger.percentB?.toFixed(2) ?? "n/a"}`);
+    lines.push(`ATR(14): ${ind.atr14?.toFixed(3) ?? "n/a"}`);
+    lines.push(`Volume: ${ctx.volume.today} (z-score ${ctx.volume.zscore.toFixed(2)}, ${ctx.volume.signal})`);
+    lines.push(`Support: ${ctx.levels.support.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
+    lines.push(`Resistance: ${ctx.levels.resistance.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
+    const perf = ctx.performance;
+    const fmtPct = (v: number | null) => (v === null ? "n/a" : (v >= 0 ? "+" : "") + (v * 100).toFixed(2) + "%");
+    lines.push(`Change: 1d ${fmtPct(perf.change1d)} · 7d ${fmtPct(perf.change7d)} · 30d ${fmtPct(perf.change30d)} · 90d ${fmtPct(perf.change90d)}`);
+  }
+  return lines.join("\n");
+}

--- a/src/core/stock/index.ts
+++ b/src/core/stock/index.ts
@@ -6,6 +6,7 @@ import { Company } from "./company";
 import Screening from "./screening";
 import { StockDataAdapter } from "../../adapters/types";
 import { VciAdapter } from "../../adapters/vci";
+import { buildAIContext, formatAIPrompt, AIContext } from "./ai-context";
 
 export default class Stock {
   trading: Trading;
@@ -27,5 +28,17 @@ export default class Stock {
 
   company(ticker: string): Company {
     return new Company(ticker, this.adapter);
+  }
+
+  aiContext(symbol: string, options: { lookback?: number } = {}): Promise<AIContext> {
+    return buildAIContext(this.adapter, symbol, options);
+  }
+
+  async toAIPrompt(
+    symbol: string,
+    options: { lookback?: number; lang?: "vi" | "en" } = {}
+  ): Promise<string> {
+    const ctx = await buildAIContext(this.adapter, symbol, options);
+    return formatAIPrompt(ctx, options.lang ?? "vi");
   }
 }

--- a/src/core/stock/pivot.ts
+++ b/src/core/stock/pivot.ts
@@ -1,0 +1,51 @@
+import { QuoteHistory } from "../../models/normalized";
+
+export interface PivotLevels {
+  support: number[];
+  resistance: number[];
+}
+
+export function detectPivots(
+  data: QuoteHistory[],
+  options: { window?: number; topN?: number } = {}
+): PivotLevels {
+  const window = options.window ?? 5;
+  const topN = options.topN ?? 3;
+
+  if (data.length < window * 2 + 1) {
+    return { support: [], resistance: [] };
+  }
+
+  const swingHighs: { date: string; value: number }[] = [];
+  const swingLows: { date: string; value: number }[] = [];
+
+  for (let i = window; i < data.length - window; i++) {
+    const cur = data[i];
+    let isHigh = true;
+    let isLow = true;
+    for (let j = i - window; j <= i + window; j++) {
+      if (j === i) continue;
+      if (data[j].high >= cur.high) isHigh = false;
+      if (data[j].low <= cur.low) isLow = false;
+      if (!isHigh && !isLow) break;
+    }
+    if (isHigh) swingHighs.push({ date: cur.date, value: cur.high });
+    if (isLow) swingLows.push({ date: cur.date, value: cur.low });
+  }
+
+  const lastClose = data[data.length - 1].close;
+
+  const resistance = swingHighs
+    .filter((p) => p.value > lastClose)
+    .sort((a, b) => a.value - b.value)
+    .slice(0, topN)
+    .map((p) => p.value);
+
+  const support = swingLows
+    .filter((p) => p.value < lastClose)
+    .sort((a, b) => b.value - a.value)
+    .slice(0, topN)
+    .map((p) => p.value);
+
+  return { support, resistance };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { Vnstock } from "./runtime";
 import { RealtimeClient, create as createRealtime, parseData } from "./realtime";
-import { createStockAPI, createCommodityAPI } from "./simple";
+import { createStockAPI, createCommodityAPI, createEasyMode } from "./simple";
 import { calendar } from "./core/market";
 import { init } from "./data";
+import { Watchlist } from "./watchlist";
 
 const vnstock = new Vnstock();
 (vnstock as any).init = init;
@@ -11,6 +12,16 @@ export const stock = createStockAPI(vnstock);
 export const commodity = createCommodityAPI(vnstock);
 export const market = { calendar };
 export const news = vnstock.news;
+
+const easy = createEasyMode(vnstock);
+export const quickQuote = easy.quickQuote;
+export const recentHistory = easy.recentHistory;
+export const compareSymbols = easy.compareSymbols;
+export const topMovers = easy.topMovers;
+
+export const watchlist = new Watchlist();
+export { Watchlist };
+export type { WatchlistStorage } from "./watchlist/storage";
 export * as VnstockTypes from "./models/normalized";
 export const realtime = { create: createRealtime, parseData };
 export { RealtimeClient };

--- a/src/indicators/atr.ts
+++ b/src/indicators/atr.ts
@@ -1,0 +1,45 @@
+import { QuoteHistory } from "../models/normalized";
+
+export interface AtrResult {
+  date: string;
+  atr: number | null;
+}
+
+export function atr(data: QuoteHistory[], period: number = 14): AtrResult[] {
+  if (period < 1) throw new Error("Period must be >= 1");
+  if (data.length === 0) return [];
+
+  const trs: number[] = [];
+  for (let i = 0; i < data.length; i++) {
+    const cur = data[i];
+    if (i === 0) {
+      trs.push(cur.high - cur.low);
+    } else {
+      const prev = data[i - 1];
+      const tr = Math.max(
+        cur.high - cur.low,
+        Math.abs(cur.high - prev.close),
+        Math.abs(cur.low - prev.close)
+      );
+      trs.push(tr);
+    }
+  }
+
+  const results: AtrResult[] = [];
+  let prevAtr: number | null = null;
+  for (let i = 0; i < data.length; i++) {
+    if (i < period - 1) {
+      results.push({ date: data[i].date, atr: null });
+    } else if (i === period - 1) {
+      let sum = 0;
+      for (let j = 0; j < period; j++) sum += trs[j];
+      prevAtr = sum / period;
+      results.push({ date: data[i].date, atr: prevAtr });
+    } else {
+      prevAtr = ((prevAtr as number) * (period - 1) + trs[i]) / period;
+      results.push({ date: data[i].date, atr: prevAtr });
+    }
+  }
+
+  return results;
+}

--- a/src/indicators/bollinger.ts
+++ b/src/indicators/bollinger.ts
@@ -1,0 +1,50 @@
+import { QuoteHistory } from "../models/normalized";
+
+export interface BollingerResult {
+  date: string;
+  upper: number | null;
+  middle: number | null;
+  lower: number | null;
+  percentB: number | null;
+}
+
+export function bollinger(
+  data: QuoteHistory[],
+  options: { period?: number; stddev?: number; field?: keyof QuoteHistory } = {}
+): BollingerResult[] {
+  const period = options.period ?? 20;
+  const stddevMul = options.stddev ?? 2;
+  const field = options.field ?? "close";
+
+  if (period < 1) throw new Error("Period must be >= 1");
+  if (data.length === 0) return [];
+
+  const results: BollingerResult[] = [];
+
+  for (let i = 0; i < data.length; i++) {
+    if (i < period - 1) {
+      results.push({ date: data[i].date, upper: null, middle: null, lower: null, percentB: null });
+      continue;
+    }
+    let sum = 0;
+    for (let j = i - period + 1; j <= i; j++) sum += data[j][field] as number;
+    const mean = sum / period;
+
+    let variance = 0;
+    for (let j = i - period + 1; j <= i; j++) {
+      const v = data[j][field] as number;
+      variance += (v - mean) * (v - mean);
+    }
+    const sd = Math.sqrt(variance / period);
+
+    const upper = mean + stddevMul * sd;
+    const lower = mean - stddevMul * sd;
+    const value = data[i][field] as number;
+    const range = upper - lower;
+    const percentB = range > 0 ? (value - lower) / range : 0;
+
+    results.push({ date: data[i].date, upper, middle: mean, lower, percentB });
+  }
+
+  return results;
+}

--- a/src/indicators/index.ts
+++ b/src/indicators/index.ts
@@ -1,3 +1,6 @@
 export { sma, type SmaResult } from "./sma";
 export { ema, type EmaResult } from "./ema";
 export { rsi, type RsiResult } from "./rsi";
+export { macd, type MacdResult } from "./macd";
+export { bollinger, type BollingerResult } from "./bollinger";
+export { atr, type AtrResult } from "./atr";

--- a/src/indicators/macd.ts
+++ b/src/indicators/macd.ts
@@ -1,0 +1,73 @@
+import { QuoteHistory } from "../models/normalized";
+
+export interface MacdResult {
+  date: string;
+  macd: number | null;
+  signal: number | null;
+  histogram: number | null;
+}
+
+function emaSeries(values: number[], period: number): (number | null)[] {
+  if (period < 1) throw new Error("Period must be >= 1");
+  const out: (number | null)[] = [];
+  const multiplier = 2 / (period + 1);
+  let prev: number | null = null;
+  for (let i = 0; i < values.length; i++) {
+    if (i < period - 1) {
+      out.push(null);
+    } else if (i === period - 1) {
+      let sum = 0;
+      for (let j = 0; j < period; j++) sum += values[j];
+      prev = sum / period;
+      out.push(prev);
+    } else {
+      const v = values[i];
+      prev = v * multiplier + (prev as number) * (1 - multiplier);
+      out.push(prev);
+    }
+  }
+  return out;
+}
+
+export function macd(
+  data: QuoteHistory[],
+  options: { fast?: number; slow?: number; signal?: number; field?: keyof QuoteHistory } = {}
+): MacdResult[] {
+  const fast = options.fast ?? 12;
+  const slow = options.slow ?? 26;
+  const signalPeriod = options.signal ?? 9;
+  const field = options.field ?? "close";
+
+  if (fast < 1 || slow < 1 || signalPeriod < 1) throw new Error("Periods must be >= 1");
+  if (fast >= slow) throw new Error("Fast period must be < slow period");
+  if (data.length === 0) return [];
+
+  const values = data.map((c) => c[field] as number);
+  const fastEma = emaSeries(values, fast);
+  const slowEma = emaSeries(values, slow);
+
+  const macdLine: (number | null)[] = values.map((_, i) => {
+    const f = fastEma[i];
+    const s = slowEma[i];
+    return f !== null && s !== null ? f - s : null;
+  });
+
+  const macdValid = macdLine.map((v) => (v === null ? 0 : v));
+  const firstValid = macdLine.findIndex((v) => v !== null);
+  const signalLine: (number | null)[] = values.map(() => null);
+  if (firstValid >= 0) {
+    const slice = macdValid.slice(firstValid);
+    const sig = emaSeries(slice, signalPeriod);
+    for (let i = 0; i < sig.length; i++) signalLine[firstValid + i] = sig[i];
+  }
+
+  return data.map((c, i) => ({
+    date: c.date,
+    macd: macdLine[i],
+    signal: signalLine[i],
+    histogram:
+      macdLine[i] !== null && signalLine[i] !== null
+        ? (macdLine[i] as number) - (signalLine[i] as number)
+        : null,
+  }));
+}

--- a/src/simple.ts
+++ b/src/simple.ts
@@ -52,6 +52,59 @@ export function createStockAPI(vnstock: Vnstock) {
   };
 }
 
+export function createEasyMode(vnstock: Vnstock) {
+  return {
+    quickQuote: async (symbol: string) => {
+      const list = await vnstock.stock.trading.priceBoard([symbol]);
+      if (list.length === 0) return null;
+      var pb = list[0] as any;
+      return {
+        symbol: pb.symbol,
+        companyName: pb.companyName,
+        price: pb.price,
+        change: pb.percentPriceChange ?? null,
+        volume: pb.totalVolume,
+        exchange: pb.exchange,
+      };
+    },
+
+    recentHistory: async (symbol: string, days: number = 30) => {
+      var d = new Date();
+      d.setDate(d.getDate() - Math.ceil(days * 1.5) - 5);
+      var start = d.toISOString().substring(0, 10);
+      var rows = await vnstock.stock.quote.history({
+        symbols: [symbol],
+        start: start,
+        timeFrame: "1D",
+        countBack: days + 10,
+      });
+      return rows.slice(-days);
+    },
+
+    compareSymbols: async (symbols: string[]) => {
+      var list = await vnstock.stock.trading.priceBoard(symbols);
+      return list.map(function (pb: any) {
+        return {
+          symbol: pb.symbol,
+          companyName: pb.companyName,
+          price: pb.price,
+          change: pb.percentPriceChange ?? null,
+          volume: pb.totalVolume,
+          exchange: pb.exchange,
+        };
+      });
+    },
+
+    topMovers: async () => {
+      var pair = await Promise.all([
+        vnstock.stock.trading.topGainers(),
+        vnstock.stock.trading.topLosers(),
+      ]);
+      return { gainers: pair[0], losers: pair[1] };
+    },
+  };
+}
+
 export function createCommodityAPI(vnstock: Vnstock) {
   return {
     gold: {

--- a/src/watchlist/index.ts
+++ b/src/watchlist/index.ts
@@ -1,0 +1,97 @@
+import { WatchlistStorage, defaultStorage } from "./storage";
+
+interface WatchlistRecord {
+  symbols: string[];
+  createdAt: string;
+}
+
+type WatchlistData = Record<string, WatchlistRecord>;
+
+export class Watchlist {
+  private storage: WatchlistStorage;
+  private cache: WatchlistData | null = null;
+
+  constructor(storage?: WatchlistStorage) {
+    this.storage = storage || defaultStorage();
+  }
+
+  setStorage(storage: WatchlistStorage) {
+    this.storage = storage;
+    this.cache = null;
+  }
+
+  private async load(): Promise<WatchlistData> {
+    if (this.cache) return this.cache;
+    var raw = await this.storage.read();
+    var data: WatchlistData = {};
+    if (raw) {
+      try {
+        var parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") data = parsed;
+      } catch (e) {
+        // fallback to empty
+      }
+    }
+    this.cache = data;
+    return data;
+  }
+
+  private async save(data: WatchlistData): Promise<void> {
+    this.cache = data;
+    await this.storage.write(JSON.stringify(data, null, 2));
+  }
+
+  async create(name: string): Promise<void> {
+    if (!name) throw new Error("Watchlist name required");
+    var data = await this.load();
+    if (data[name]) return;
+    data[name] = { symbols: [], createdAt: new Date().toISOString().substring(0, 10) };
+    await this.save(data);
+  }
+
+  async delete(name: string): Promise<void> {
+    var data = await this.load();
+    if (!data[name]) return;
+    delete data[name];
+    await this.save(data);
+  }
+
+  async add(name: string, symbols: string | string[]): Promise<void> {
+    var data = await this.load();
+    if (!data[name]) {
+      data[name] = { symbols: [], createdAt: new Date().toISOString().substring(0, 10) };
+    }
+    var list = Array.isArray(symbols) ? symbols : [symbols];
+    var existing = data[name].symbols;
+    for (var i = 0; i < list.length; i++) {
+      var s = list[i].toUpperCase();
+      if (existing.indexOf(s) === -1) existing.push(s);
+    }
+    await this.save(data);
+  }
+
+  async remove(name: string, symbol: string): Promise<void> {
+    var data = await this.load();
+    if (!data[name]) return;
+    var upper = symbol.toUpperCase();
+    data[name].symbols = data[name].symbols.filter(function (s) {
+      return s !== upper;
+    });
+    await this.save(data);
+  }
+
+  async list(name: string): Promise<string[]> {
+    var data = await this.load();
+    return data[name] ? data[name].symbols.slice() : [];
+  }
+
+  async listAll(): Promise<string[]> {
+    var data = await this.load();
+    return Object.keys(data);
+  }
+
+  async has(name: string): Promise<boolean> {
+    var data = await this.load();
+    return !!data[name];
+  }
+}

--- a/src/watchlist/storage.ts
+++ b/src/watchlist/storage.ts
@@ -1,0 +1,70 @@
+export interface WatchlistStorage {
+  read(): Promise<string | null>;
+  write(json: string): Promise<void>;
+}
+
+class NodeFileStorage implements WatchlistStorage {
+  private filePath: string;
+  private fs: any;
+  private path: any;
+  private os: any;
+
+  constructor() {
+    this.fs = require("fs");
+    this.path = require("path");
+    this.os = require("os");
+    var home = this.os.homedir();
+    var dir = this.path.join(home, ".vnstock-js");
+    if (!this.fs.existsSync(dir)) this.fs.mkdirSync(dir, { recursive: true });
+    this.filePath = this.path.join(dir, "watchlist.json");
+  }
+
+  async read(): Promise<string | null> {
+    if (!this.fs.existsSync(this.filePath)) return null;
+    try {
+      var content = this.fs.readFileSync(this.filePath, "utf8");
+      JSON.parse(content);
+      return content;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  async write(json: string): Promise<void> {
+    var tmp = this.filePath + ".tmp";
+    this.fs.writeFileSync(tmp, json, "utf8");
+    this.fs.renameSync(tmp, this.filePath);
+  }
+}
+
+class BrowserNoopStorage implements WatchlistStorage {
+  private warned = false;
+
+  async read(): Promise<string | null> {
+    this.warn();
+    return null;
+  }
+
+  async write(_json: string): Promise<void> {
+    this.warn();
+  }
+
+  private warn() {
+    if (this.warned) return;
+    this.warned = true;
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        "[vnstock-js] Watchlist persistence is not available in browser. " +
+          "Inject custom storage via vnstock.watchlist.setStorage(adapter)."
+      );
+    }
+  }
+}
+
+export function defaultStorage(): WatchlistStorage {
+  var isNode =
+    typeof process !== "undefined" &&
+    process.versions != null &&
+    process.versions.node != null;
+  return isNode ? new NodeFileStorage() : new BrowserNoopStorage();
+}


### PR DESCRIPTION
## Summary

Repositioning vnstock-js từ "VN stock SDK" sang **"AI Research Toolkit cho cổ phiếu Việt Nam"**. Bundle 5 capability bundle trong 1 release để có coherent launch story.

## 5 capabilities

### 1. MCP server (`vnstock mcp` subcommand)
- 11 tools bilingual (Vi + En) cho Claude Desktop / Cursor / VS Code / Claude Code CLI
- 8 data tools: `get_quote`, `get_history`, `search_symbols`, `list_symbols`, `top_movers`, `is_trade_day`, `get_trading_calendar`, `get_company_info`
- 3 AI tools: `get_ai_context` (structured JSON), `to_ai_prompt` (plain-text), `compare_symbols`
- Session cache 30s quote / 60s aiContext giảm pressure VCI
- New dep: `@modelcontextprotocol/sdk@^1.29.0`

### 2. Indicators v2 (pure functions)
- `macd(candles, opts?)` — 12/26/9 default
- `bollinger(candles, opts?)` — 20-period 2-stddev, `percentB` 0..1
- `atr(candles, period?)` — Wilder smoothing, 14-period default

### 3. AI context layer
- `stock.aiContext(symbol)` — structured JSON: trend, indicators snapshot, S/R pivot, volume z-score, performance 1d/7d/30d/90d
- `stock.toAIPrompt(symbol, { lang })` — plain-text format cho non-MCP LLM
- Trend classifier rules-based (EMA chain + slope)

### 4. Easy-mode helpers
- `vnstock.quickQuote("VCB")`, `vnstock.recentHistory("VCB", 30)`, `vnstock.compareSymbols([...])`, `vnstock.topMovers()`

### 5. Watchlist module
- `vnstock.watchlist` CRUD + Node persist `~/.vnstock-js/watchlist.json`
- Browser opt-in storage adapter

## CLI UX patches
- `vnstock <SYMBOL>` shortcut (default-to-quote)
- Multi-symbol: `vnstock MBB,FPT,VCB`
- Quote header thêm timestamp

## Test plan

- [x] **Indicators v2**: 24 new tests (MACD/Bollinger/ATR), pure-function golden values
- [x] **AI context**: 16 tests with mock adapter (trend/snapshot/volume/pivot/format)
- [x] **Watchlist**: 12 tests CRUD + persist + invalid JSON fallback
- [x] **MCP**: 27 tests (16 handlers mock-based + 11 schemas)
- [x] **Easy-mode**: 4 tests real API
- [x] **CLI UX**: handleQuote 7 tests (multi-symbol via comma + shortcut + timestamp)
- [x] **Full suite**: 340 pass / 3 intentional skip / 0 fail (vs 256 baseline v1.3.3)
- [x] **Manual MCP smoke**: stdio JSON-RPC verified `get_quote`, `get_ai_context`, `to_ai_prompt` against real VCI API
- [x] **`npm run build`** xanh, `npx tsc --noEmit` xanh
- [x] **`vnstock mcp`** startup <500ms, list 11 tools correctly

## Install MCP (Claude Code CLI)

```bash
claude mcp add --scope user vnstock npx -y vnstock-js mcp
claude mcp list
# Expected: "vnstock: ... - ✓ Connected"
```

## Install MCP (Claude Desktop)

```json
{
  "mcpServers": {
    "vnstock": {
      "command": "npx",
      "args": ["-y", "vnstock-js", "mcp"]
    }
  }
}
```

## Known issues (carry-over từ v1.3.3)

- `listing.allSymbols()` skip — `ai.vietcap.com.vn` 403
- `screening` vẫn dùng GraphQL deprecated
- Commodity SJC 403 — pre-existing

## Roadmap context

Phase 1 của [v2.0 AI-Native Vision](https://github.com/ttqteo/vnstock-js/blob/roadmap/docs/superpowers/specs/2026-05-14-v2.0-ai-native-vision.md). Spec: [v1.4.0 design](https://github.com/ttqteo/vnstock-js/blob/roadmap/docs/superpowers/specs/2026-04-14-v1.4.0-mcp-server-design.md). Plan: [v1.4.0 implementation plan](https://github.com/ttqteo/vnstock-js/blob/roadmap/docs/superpowers/plans/2026-05-14-v1.4.0-ai-native-foundation.md).

Next: v1.5 Power Workflow (patterns + alerts + portfolio + screeners).