### PR TITLE
feat: v1.4.1 — Indicators expansion + network resilience + stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,44 @@
 # Changelog
 
-## 1.4.1 — Indicators Expansion + Network Resilience
+## 1.4.1 — Indicators Expansion + Network Resilience + Stability
 
-Bổ sung 2 indicator mới (SuperTrend + Ichimoku Cloud), gia tăng độ ổn định khi gặp Cloudflare rate-limit, deprecate endpoint SJC bị 403.
+Bổ sung 2 indicator mới (SuperTrend + Ichimoku Cloud), gia tăng độ ổn định khi gặp Cloudflare rate-limit, deprecate endpoint SJC bị 403, gate integration tests sau env `INTEGRATION=1`, TTL cache cho VCI static endpoints.
 
 ### Thêm
 
 - **`superTrend(candles, opts?)`** — trend-following indicator (default `period=10, multiplier=3`, chuẩn TradingView/pandas_ta). Trả `superTrend`, `direction` (`bullish`/`bearish`), `upperBand`, `lowerBand` cho từng bar. Dùng ATR module có sẵn.
 - **`ichimoku(candles, opts?)`** — Ichimoku Cloud (default `tenkan=9, kijun=26, senkou=52, displacement=26`). Convention: `senkouSpanA[i]` / `senkouSpanB[i]` là **giá trị cloud hiện tại tại i** (đã shift forward từ i-26), tiện cho so sánh `close[i]` vs cloud. `chikouSpan[i] = close[i+26]`, null cho 26 bars cuối.
+- **`ichimokuFutureCloud(candles, opts?)`** — projection cloud 26 phiên tới (chart use case). Trả `IchimokuFutureBar[]` với `offset` 1..26, `senkouSpanA/B`, `cloudTop/Bottom`. Không include trong `aiContext` (chỉ historical).
 - **AI context layer extended** — `vnstock.stock.aiContext(symbol)` và `toAIPrompt(symbol)` nay include:
   - `superTrend: { value, direction }`
   - `ichimoku: { tenkanSen, kijunSen, cloudTop, cloudBottom, priceVsCloud, tkCross }`
   - `formatAIPrompt` output thêm dòng `SuperTrend:` và `Ichimoku:` cho cả `vi` lẫn `en`.
+- **`classifyTrend()` ảnh hưởng bởi SuperTrend + Ichimoku** — EMA trend được confirm/contradict bởi 2 indicator mới:
+  - Bullish EMA + ST bullish + price above cloud → strength + 0.2
+  - Bullish EMA nhưng ST bearish + price below cloud → strength × 0.5
+  - Neutral EMA + ST & Ichimoku đồng thuận → upgrade direction (strength=0.4)
 - **MCP tool descriptions** — `get_ai_context` và `to_ai_prompt` cập nhật mention SuperTrend + Ichimoku.
-- **Root export** — `superTrend` và `ichimoku` exposed ở `src/index.ts` cho user import trực tiếp.
+- **Root export** — `superTrend`, `ichimoku` exposed ở `src/index.ts` cho user import trực tiếp.
+- **`VciAdapter({ cache })` option** — TTL in-memory cache cho 3 endpoints static-ish: `icb-codes` (1h), `search-bar` (30 min), `financial-statement/metrics` per symbol (1h). Default `cache: true`. Opt-out: `new VciAdapter({ cache: false })`. Public method `clearCache()` để invalidate manual.
 
 ### Sửa
 
 - **Cloudflare Error 1015 detection** (issue #10) — `pipeline/fetch.ts` nay detect Cloudflare rate-limit qua `cf-ray` header + body chứa `Error 1015` hoặc `cloudflare` (cho HTTP 4xx). Throw `RateLimitError` thay vì `ApiError`, retry với exponential backoff 30s → 60s → 120s.
 - **`goldPriceSJC()` deprecated** (issue #12) — SJC endpoint trả 403 từ non-VN IPs (đã skip test từ v1.3.3). Method giờ log `console.warn` redirect sang `goldPriceBTMC()` / `goldPriceGiaVangNet()`. Giữ method cho backwards compat, sẽ remove ở v2.0.
+- **Tests gate `INTEGRATION=1`** (issue #9) — `listing.test.ts`, `company.test.ts`, `financial.test.ts` skip real-API blocks mặc định. Chạy full integration: `INTEGRATION=1 npm test`. Default CI nay mock-based, không hit Vietcap → tránh rate-limit/Cloudflare 1015 trong dev loop.
 
 ### Nội bộ
 
-- 34 new tests (12 supertrend + 16 ichimoku + 6 cloudflare-1015) + extend ai-context test.
+- 60+ new tests (12 supertrend + 22 ichimoku + 6 cloudflare-1015 + 5 vci-cache + extends ai-context + mock-based listing/company/financial).
+- 45 test suites, 383 pass / 18 skip (skip ~ integration-gated).
 - ATR + Bollinger + MACD vẫn dùng subpath import (`vnstock-js/dist/indicators/*`) — không backfill root export trong patch này.
 
 ### Migration notes
 
 - Không breaking. Existing `aiContext` consumer chỉ thấy thêm 2 field mới trong `indicators` (`superTrend`, `ichimoku`); JSON nay lớn hơn ~200 bytes.
 - `goldPriceSJC()` deprecated nhưng vẫn callable; chuyển sang `goldPriceBTMC()` để remove console.warn.
+- `VciAdapter` mặc định bật cache. Nếu code cũ phụ thuộc fresh API mỗi call cho `icb-codes`/`search-bar`/`metrics`, pass `{ cache: false }` hoặc gọi `clearCache()`.
+- Tests cần real-API verification: chạy `INTEGRATION=1 npm test` thay vì `npm test`.
 
 ## 1.4.0 — AI-Native Foundation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.4.1 — Indicators Expansion + Network Resilience
+
+Bổ sung 2 indicator mới (SuperTrend + Ichimoku Cloud), gia tăng độ ổn định khi gặp Cloudflare rate-limit, deprecate endpoint SJC bị 403.
+
+### Thêm
+
+- **`superTrend(candles, opts?)`** — trend-following indicator (default `period=10, multiplier=3`, chuẩn TradingView/pandas_ta). Trả `superTrend`, `direction` (`bullish`/`bearish`), `upperBand`, `lowerBand` cho từng bar. Dùng ATR module có sẵn.
+- **`ichimoku(candles, opts?)`** — Ichimoku Cloud (default `tenkan=9, kijun=26, senkou=52, displacement=26`). Convention: `senkouSpanA[i]` / `senkouSpanB[i]` là **giá trị cloud hiện tại tại i** (đã shift forward từ i-26), tiện cho so sánh `close[i]` vs cloud. `chikouSpan[i] = close[i+26]`, null cho 26 bars cuối.
+- **AI context layer extended** — `vnstock.stock.aiContext(symbol)` và `toAIPrompt(symbol)` nay include:
+  - `superTrend: { value, direction }`
+  - `ichimoku: { tenkanSen, kijunSen, cloudTop, cloudBottom, priceVsCloud, tkCross }`
+  - `formatAIPrompt` output thêm dòng `SuperTrend:` và `Ichimoku:` cho cả `vi` lẫn `en`.
+- **MCP tool descriptions** — `get_ai_context` và `to_ai_prompt` cập nhật mention SuperTrend + Ichimoku.
+- **Root export** — `superTrend` và `ichimoku` exposed ở `src/index.ts` cho user import trực tiếp.
+
+### Sửa
+
+- **Cloudflare Error 1015 detection** (issue #10) — `pipeline/fetch.ts` nay detect Cloudflare rate-limit qua `cf-ray` header + body chứa `Error 1015` hoặc `cloudflare` (cho HTTP 4xx). Throw `RateLimitError` thay vì `ApiError`, retry với exponential backoff 30s → 60s → 120s.
+- **`goldPriceSJC()` deprecated** (issue #12) — SJC endpoint trả 403 từ non-VN IPs (đã skip test từ v1.3.3). Method giờ log `console.warn` redirect sang `goldPriceBTMC()` / `goldPriceGiaVangNet()`. Giữ method cho backwards compat, sẽ remove ở v2.0.
+
+### Nội bộ
+
+- 34 new tests (12 supertrend + 16 ichimoku + 6 cloudflare-1015) + extend ai-context test.
+- ATR + Bollinger + MACD vẫn dùng subpath import (`vnstock-js/dist/indicators/*`) — không backfill root export trong patch này.
+
+### Migration notes
+
+- Không breaking. Existing `aiContext` consumer chỉ thấy thêm 2 field mới trong `indicators` (`superTrend`, `ichimoku`); JSON nay lớn hơn ~200 bytes.
+- `goldPriceSJC()` deprecated nhưng vẫn callable; chuyển sang `goldPriceBTMC()` để remove console.warn.
+
 ## 1.4.0 — AI-Native Foundation
 
 Repositioning vnstock-js từ "VN stock SDK" sang "AI Research Toolkit cho cổ phiếu Việt Nam". Bundle MCP server + indicators v2 + AI context layer + easy-mode helpers + watchlist trong 1 release.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ Thư viện JavaScript/TypeScript lấy dữ liệu thị trường chứng kho�
 - **Tài chính** -- Bảng cân đối, kết quả kinh doanh, lưu chuyển tiền tệ
 - **Niêm yết** -- Danh sách mã theo sàn, ngành ICB, nhóm (VN30, HNX30...)
 - **Sàng lọc** -- Lọc cổ phiếu theo PE, ROE, vốn hóa...
-- **Chỉ báo kỹ thuật** -- SMA, EMA, RSI
-- **Hàng hóa** -- Giá vàng (BTMC, SJC, GiaVang.net), tỷ giá VCB
+- **Hàng hóa** -- Giá vàng (BTMC, GiaVang.net; SJC deprecated do 403), tỷ giá VCB
 - **Tin tức** -- Tổng hợp tin tài chính VN hàng ngày (Vietstock, VnExpress, Tin Nhanh CK, ...)
 - **Realtime** -- WebSocket dữ liệu giá trực tiếp (SSI)
-- **Chỉ báo kỹ thuật** -- SMA, EMA, RSI, MACD, Bollinger Bands, ATR
+- **Chỉ báo kỹ thuật** -- SMA, EMA, RSI, MACD, Bollinger Bands, ATR, SuperTrend, Ichimoku Cloud
 - **AI context** -- `aiContext()` trả structured trend/RSI/MACD/S-R/volume cho LLM reasoning
 - **MCP server** -- `vnstock mcp` cho Claude Desktop / Cursor / VS Code
 - **Watchlist** -- quản lý danh sách mã yêu thích, persist `~/.vnstock-js/watchlist.json`

--- a/__tests__/ai-context.test.ts
+++ b/__tests__/ai-context.test.ts
@@ -59,6 +59,18 @@ describe("classifyTrend", () => {
     expect(r.direction).toBe("neutral");
     expect(r.strength).toBe(0);
   });
+
+  it("appends SuperTrend + Ichimoku confirmation to rationale on bullish uptrend", () => {
+    const r = classifyTrend(makeUptrend(220));
+    expect(r.direction).toBe("bullish");
+    expect(r.rationale).toMatch(/ST.*Ichimoku|Ichimoku.*ST/i);
+  });
+
+  it("appends SuperTrend + Ichimoku confirmation to rationale on bearish downtrend", () => {
+    const r = classifyTrend(makeDowntrend(220));
+    expect(r.direction).toBe("bearish");
+    expect(r.rationale).toMatch(/ST.*Ichimoku|Ichimoku.*ST/i);
+  });
 });
 
 describe("snapshotIndicators", () => {

--- a/__tests__/ai-context.test.ts
+++ b/__tests__/ai-context.test.ts
@@ -70,6 +70,14 @@ describe("snapshotIndicators", () => {
     expect(snap.sma[200]).not.toBeNull();
     expect(snap.bollinger.percentB).not.toBeNull();
     expect(snap.atr14).not.toBeNull();
+    expect(snap.superTrend.value).not.toBeNull();
+    expect(snap.superTrend.direction).not.toBeNull();
+    expect(snap.ichimoku.tenkanSen).not.toBeNull();
+    expect(snap.ichimoku.kijunSen).not.toBeNull();
+    expect(snap.ichimoku.cloudTop).not.toBeNull();
+    expect(snap.ichimoku.cloudBottom).not.toBeNull();
+    expect(["above", "below", "inside", null]).toContain(snap.ichimoku.priceVsCloud);
+    expect(["bullish", "bearish", "none"]).toContain(snap.ichimoku.tkCross);
   });
 
   it("gracefully handles short data (< 200)", () => {
@@ -187,6 +195,9 @@ describe("formatAIPrompt", () => {
     expect(text).toContain("Support:");
     expect(text).toContain("Resistance:");
     expect(text).toContain("Change:");
+    expect(text).toContain("SuperTrend:");
+    expect(text).toContain("Ichimoku:");
+    expect(text).toContain("TK cross:");
   });
 
   it("en output contains English labels", async () => {
@@ -197,5 +208,8 @@ describe("formatAIPrompt", () => {
     const text = formatAIPrompt(ctx, "en");
     expect(text).toContain("Trend:");
     expect(text).toContain("Bollinger %B:");
+    expect(text).toContain("SuperTrend:");
+    expect(text).toContain("Ichimoku:");
+    expect(text).toContain("TK cross:");
   });
 });

--- a/__tests__/company.test.ts
+++ b/__tests__/company.test.ts
@@ -1,7 +1,11 @@
+import axios from "axios";
 import vnstock from "../src";
 import { Company } from "../src/core/stock/company";
 
-describe("Company", () => {
+const RUN_INTEGRATION = process.env.INTEGRATION === "1";
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+describeIntegration("Company (integration — INTEGRATION=1)", () => {
   let company: Company;
 
   beforeAll(() => {
@@ -72,4 +76,83 @@ describe("Company", () => {
     const data = await company.subsidiaries();
     expect(Array.isArray(data)).toBe(true);
   }, 30000);
+});
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Company (mocked)", () => {
+  let company: Company;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    company = new Company("VCI");
+  });
+
+  // Adapter's fetchCompanyOverview assembles output from 5 endpoint calls
+  // (details, shareholder-structure, shareholder, events, news). The mock below
+  // sets a default empty-data response for all 5; assertions stay on transform
+  // shape rather than full content matching.
+  function mockOverviewEmpty() {
+    mockedAxios.request.mockResolvedValue({ data: { data: [] }, headers: {} });
+  }
+
+  function mockOverviewDetails(detailsPayload: any) {
+    // details endpoint returns `{ data: { organCode, sectorVn, ... } }`,
+    // others return arrays — call mockImplementation to differentiate by URL.
+    mockedAxios.request.mockImplementation((config: any) => {
+      if (typeof config.url === "string" && config.url.indexOf("/details") !== -1) {
+        return Promise.resolve({ data: detailsPayload, headers: {} });
+      }
+      return Promise.resolve({ data: { data: [] }, headers: {} });
+    });
+  }
+
+  it("profile() normalizes details → industry/issuedShares", async () => {
+    mockOverviewDetails({
+      data: {
+        organCode: "VCI",
+        numberOfSharesMktCap: 408460396,
+        sectorVn: "Tài chính",
+        sector: "Finance",
+        viOrganProfile: "<p>VCI là...</p>",
+        enOrganProfile: "<p>VCI is...</p>",
+      },
+    });
+    const data = await company.profile();
+    expect(data).toHaveProperty("industry");
+    expect(data).toHaveProperty("industryEn");
+    expect(data).toHaveProperty("issuedShares");
+    expect(data).not.toHaveProperty("issueShare");
+    expect(data).not.toHaveProperty("icbName3");
+  });
+
+  it("shareholders() returns empty array for empty payload", async () => {
+    mockOverviewEmpty();
+    const data = await company.shareholders();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBe(0);
+  });
+
+  it("officers() returns empty array for empty payload", async () => {
+    mockOverviewEmpty();
+    const data = await company.officers();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBe(0);
+  });
+
+  it("events() returns empty array for empty payload", async () => {
+    mockOverviewEmpty();
+    const data = await company.events();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBe(0);
+  });
+
+  it("news() returns empty array for empty payload", async () => {
+    mockOverviewEmpty();
+    const data = await company.news();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBe(0);
+  });
+
 });

--- a/__tests__/financial.test.ts
+++ b/__tests__/financial.test.ts
@@ -1,6 +1,10 @@
+import axios from "axios";
 import vnstock from "../src";
 
-describe("Financial", () => {
+const RUN_INTEGRATION = process.env.INTEGRATION === "1";
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+describeIntegration("Financial (integration — INTEGRATION=1)", () => {
   it("should return normalized balance sheet", async () => {
     const data = await vnstock.stock.financials.balanceSheet({
       symbol: "VCI",
@@ -31,4 +35,41 @@ describe("Financial", () => {
     expect(data).toHaveProperty("data");
     expect(data.data).toHaveProperty("symbol");
   }, 30000);
+});
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Financial (mocked)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: empty payloads for all 3 endpoints
+    mockedAxios.request.mockResolvedValue({ data: { data: {} }, headers: {} });
+  });
+
+  it("balanceSheet() returns { data, mapping } shape", async () => {
+    const data = await vnstock.stock.financials.balanceSheet({
+      symbol: "VCI",
+      period: "quarter",
+    });
+    expect(data).toHaveProperty("data");
+    expect(data).toHaveProperty("mapping");
+    expect(data.mapping).toHaveProperty("ratio");
+    expect(data.mapping).toHaveProperty("unit");
+  });
+
+  it("incomeStatement() returns { data, mapping } shape", async () => {
+    const data = await vnstock.stock.financials.incomeStatement({
+      symbol: "VCI",
+      period: "year",
+    });
+    expect(data).toHaveProperty("data");
+    expect(data).toHaveProperty("mapping");
+  });
+
+  it("cashFlow() returns { data, mapping } shape", async () => {
+    const data = await vnstock.stock.financials.cashFlow({ symbol: "VCI" });
+    expect(data).toHaveProperty("data");
+    expect(data).toHaveProperty("mapping");
+  });
 });

--- a/__tests__/indicators/ichimoku.test.ts
+++ b/__tests__/indicators/ichimoku.test.ts
@@ -1,4 +1,4 @@
-import { ichimoku } from "../../src/indicators/ichimoku";
+import { ichimoku, ichimokuFutureCloud } from "../../src/indicators/ichimoku";
 import { QuoteHistory } from "../../src/models/normalized";
 
 function bar(date: string, open: number, high: number, low: number, close: number): QuoteHistory {
@@ -123,5 +123,51 @@ describe("ichimoku", () => {
     expect(r1[60].tenkanSen).toBeCloseTo(r2[60].tenkanSen as number);
     expect(r1[60].kijunSen).toBeCloseTo(r2[60].kijunSen as number);
     expect(r1[60].senkouSpanA).toBeCloseTo(r2[60].senkouSpanA as number);
+  });
+});
+
+describe("ichimokuFutureCloud", () => {
+  it("returns empty for empty input", () => {
+    expect(ichimokuFutureCloud([])).toEqual([]);
+  });
+
+  it("throws on invalid period", () => {
+    expect(() => ichimokuFutureCloud(makeLinearRamp(60), { tenkan: 0 })).toThrow();
+  });
+
+  it("returns up to displacement bars when enough data", () => {
+    const data = makeLinearRamp(100);
+    const fc = ichimokuFutureCloud(data);
+    expect(fc.length).toBeGreaterThan(0);
+    expect(fc.length).toBeLessThanOrEqual(26);
+  });
+
+  it("offsets are 1..displacement (no zero, no negatives)", () => {
+    const data = makeLinearRamp(100);
+    const fc = ichimokuFutureCloud(data);
+    for (const b of fc) {
+      expect(b.offset).toBeGreaterThanOrEqual(1);
+      expect(b.offset).toBeLessThanOrEqual(26);
+    }
+  });
+
+  it("cloudTop >= cloudBottom", () => {
+    const data = makeLinearRamp(100);
+    const fc = ichimokuFutureCloud(data);
+    for (const b of fc) {
+      expect(b.cloudTop).toBeGreaterThanOrEqual(b.cloudBottom);
+    }
+  });
+
+  it("first future bar (offset=1) extends from current senkouSpanA at index n", () => {
+    // For offset=1, src = n-1-26+1 = n-26
+    // senkouSpanA = (tenkan[n-26] + kijun[n-26]) / 2
+    const data = makeLinearRamp(100);
+    const r = ichimoku(data);
+    const fc = ichimokuFutureCloud(data);
+    const first = fc[0];
+    const t = r[data.length - 26].tenkanSen as number;
+    const k = r[data.length - 26].kijunSen as number;
+    expect(first.senkouSpanA).toBeCloseTo((t + k) / 2);
   });
 });

--- a/__tests__/indicators/ichimoku.test.ts
+++ b/__tests__/indicators/ichimoku.test.ts
@@ -1,0 +1,127 @@
+import { ichimoku } from "../../src/indicators/ichimoku";
+import { QuoteHistory } from "../../src/models/normalized";
+
+function bar(date: string, open: number, high: number, low: number, close: number): QuoteHistory {
+  return { date, open, high, low, close, volume: 0 };
+}
+
+function makeLinearRamp(n: number): QuoteHistory[] {
+  const out: QuoteHistory[] = [];
+  for (let i = 0; i < n; i++) {
+    const base = 100 + i;
+    const date = `2024-${String(Math.floor(i / 30) + 1).padStart(2, "0")}-${String((i % 30) + 1).padStart(2, "0")}`;
+    out.push(bar(date, base, base + 2, base - 2, base));
+  }
+  return out;
+}
+
+describe("ichimoku", () => {
+  it("throws on tenkan < 1", () => {
+    expect(() => ichimoku(makeLinearRamp(60), { tenkan: 0 })).toThrow();
+  });
+
+  it("throws on kijun < 1", () => {
+    expect(() => ichimoku(makeLinearRamp(60), { kijun: 0 })).toThrow();
+  });
+
+  it("throws on senkou < 1", () => {
+    expect(() => ichimoku(makeLinearRamp(60), { senkou: 0 })).toThrow();
+  });
+
+  it("throws on displacement < 1", () => {
+    expect(() => ichimoku(makeLinearRamp(60), { displacement: 0 })).toThrow();
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(ichimoku([])).toEqual([]);
+  });
+
+  it("output length equals input length", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    expect(r).toHaveLength(60);
+  });
+
+  it("insufficient data (< 9 bars) returns all-null tenkan", () => {
+    const data = makeLinearRamp(8);
+    const r = ichimoku(data);
+    for (const e of r) {
+      expect(e.tenkanSen).toBeNull();
+    }
+  });
+
+  it("tenkanSen[8] equals donchian(9) on linear ramp", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    // bars 0..8: highs 102..110, lows 98..106
+    // donchian = (110 + 98) / 2 = 104
+    expect(r[8].tenkanSen).toBeCloseTo(104);
+  });
+
+  it("kijunSen[25] equals donchian(26) on linear ramp", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    // bars 0..25: high max=127 (bar 25, base 125+2), low min=98 (bar 0)
+    // donchian = (127 + 98) / 2 = 112.5
+    expect(r[25].kijunSen).toBeCloseTo(112.5);
+  });
+
+  it("senkouSpanA at i uses tenkan/kijun from i-26 (current cloud convention)", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    // At i=52: senkouSpanA = (tenkan[26] + kijun[26]) / 2
+    const t26 = r[26].tenkanSen as number;
+    const k26 = r[26].kijunSen as number;
+    expect(r[52].senkouSpanA).toBeCloseTo((t26 + k26) / 2);
+  });
+
+  it("senkouSpanA is null before displacement bars", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    for (let i = 0; i < 26; i++) {
+      expect(r[i].senkouSpanA).toBeNull();
+      expect(r[i].senkouSpanB).toBeNull();
+    }
+  });
+
+  it("chikouSpan is null for last 26 bars", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    for (let i = data.length - 26; i < data.length; i++) {
+      expect(r[i].chikouSpan).toBeNull();
+    }
+  });
+
+  it("chikouSpan[i] equals close[i+26]", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    expect(r[0].chikouSpan).toBeCloseTo(data[26].close);
+    expect(r[10].chikouSpan).toBeCloseTo(data[36].close);
+  });
+
+  it("cloudTop >= cloudBottom when both defined", () => {
+    const data = makeLinearRamp(80);
+    const r = ichimoku(data);
+    for (const e of r) {
+      if (e.cloudTop !== null && e.cloudBottom !== null) {
+        expect(e.cloudTop).toBeGreaterThanOrEqual(e.cloudBottom);
+      }
+    }
+  });
+
+  it("preserves dates", () => {
+    const data = makeLinearRamp(60);
+    const r = ichimoku(data);
+    expect(r[0].date).toBe(data[0].date);
+    expect(r[59].date).toBe(data[59].date);
+  });
+
+  it("uses default periods 9/26/52/26", () => {
+    const data = makeLinearRamp(80);
+    const r1 = ichimoku(data);
+    const r2 = ichimoku(data, { tenkan: 9, kijun: 26, senkou: 52, displacement: 26 });
+    expect(r1[60].tenkanSen).toBeCloseTo(r2[60].tenkanSen as number);
+    expect(r1[60].kijunSen).toBeCloseTo(r2[60].kijunSen as number);
+    expect(r1[60].senkouSpanA).toBeCloseTo(r2[60].senkouSpanA as number);
+  });
+});

--- a/__tests__/indicators/supertrend.test.ts
+++ b/__tests__/indicators/supertrend.test.ts
@@ -1,0 +1,115 @@
+import { superTrend } from "../../src/indicators/supertrend";
+import { QuoteHistory } from "../../src/models/normalized";
+
+function bar(date: string, open: number, high: number, low: number, close: number): QuoteHistory {
+  return { date, open, high, low, close, volume: 0 };
+}
+
+describe("superTrend", () => {
+  const linearRamp: QuoteHistory[] = [];
+  for (let i = 0; i < 30; i++) {
+    const base = 100 + i;
+    linearRamp.push(bar(`2024-01-${String(i + 1).padStart(2, "0")}`, base, base + 1, base - 1, base));
+  }
+
+  it("throws on period < 1", () => {
+    expect(() => superTrend(linearRamp, { period: 0 })).toThrow();
+  });
+
+  it("throws on multiplier <= 0", () => {
+    expect(() => superTrend(linearRamp, { multiplier: 0 })).toThrow();
+    expect(() => superTrend(linearRamp, { multiplier: -1 })).toThrow();
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(superTrend([])).toEqual([]);
+  });
+
+  it("output length equals input length", () => {
+    const r = superTrend(linearRamp);
+    expect(r).toHaveLength(linearRamp.length);
+  });
+
+  it("first period-1 entries are null", () => {
+    const r = superTrend(linearRamp, { period: 10, multiplier: 3 });
+    for (let i = 0; i < 9; i++) {
+      expect(r[i].superTrend).toBeNull();
+      expect(r[i].direction).toBeNull();
+      expect(r[i].upperBand).toBeNull();
+      expect(r[i].lowerBand).toBeNull();
+    }
+    expect(r[9].superTrend).not.toBeNull();
+    expect(r[9].direction).not.toBeNull();
+  });
+
+  it("direction is consistent: bullish ↔ close > superTrend", () => {
+    const r = superTrend(linearRamp);
+    for (let i = 0; i < r.length; i++) {
+      if (r[i].superTrend === null) continue;
+      if (r[i].direction === "bullish") {
+        expect(linearRamp[i].close).toBeGreaterThan(r[i].superTrend as number);
+      } else if (r[i].direction === "bearish") {
+        expect(linearRamp[i].close).toBeLessThanOrEqual(r[i].superTrend as number);
+      }
+    }
+  });
+
+  it("preserves dates", () => {
+    const r = superTrend(linearRamp);
+    expect(r[0].date).toBe("2024-01-01");
+    expect(r[29].date).toBe("2024-01-30");
+  });
+
+  it("uses default period=10 multiplier=3", () => {
+    const r1 = superTrend(linearRamp);
+    const r2 = superTrend(linearRamp, { period: 10, multiplier: 3 });
+    expect(r1[15].superTrend).toBeCloseTo(r2[15].superTrend as number);
+  });
+
+  it("detects direction flip when close crosses upward through superTrend", () => {
+    // 15 flat bars → 10 explosive up bars
+    const data: QuoteHistory[] = [];
+    for (let i = 0; i < 15; i++) {
+      data.push(bar(`2024-01-${String(i + 1).padStart(2, "0")}`, 100, 101, 99, 100));
+    }
+    for (let i = 0; i < 10; i++) {
+      const base = 100 + (i + 1) * 5;
+      data.push(bar(`2024-01-${String(15 + i + 1).padStart(2, "0")}`, base, base + 1, base - 1, base));
+    }
+    const r = superTrend(data, { period: 10, multiplier: 3 });
+    // Late bars should flip to bullish after the explosive move
+    const lastDir = r[r.length - 1].direction;
+    expect(lastDir).toBe("bullish");
+  });
+
+  it("detects direction flip when close crosses downward through superTrend", () => {
+    const data: QuoteHistory[] = [];
+    for (let i = 0; i < 15; i++) {
+      data.push(bar(`2024-01-${String(i + 1).padStart(2, "0")}`, 100, 101, 99, 100));
+    }
+    for (let i = 0; i < 10; i++) {
+      const base = 100 - (i + 1) * 5;
+      data.push(bar(`2024-01-${String(15 + i + 1).padStart(2, "0")}`, base, base + 1, base - 1, base));
+    }
+    const r = superTrend(data, { period: 10, multiplier: 3 });
+    const lastDir = r[r.length - 1].direction;
+    expect(lastDir).toBe("bearish");
+  });
+
+  it("upperBand and lowerBand bracket the close in steady state", () => {
+    // After enough bars, bands should bracket roughly around price
+    const r = superTrend(linearRamp);
+    const last = r[r.length - 1];
+    expect(last.upperBand).not.toBeNull();
+    expect(last.lowerBand).not.toBeNull();
+    expect(last.upperBand as number).toBeGreaterThan(last.lowerBand as number);
+  });
+
+  it("returns null for data shorter than period", () => {
+    const small = linearRamp.slice(0, 5);
+    const r = superTrend(small, { period: 10 });
+    for (const e of r) {
+      expect(e.superTrend).toBeNull();
+    }
+  });
+});

--- a/__tests__/listing.test.ts
+++ b/__tests__/listing.test.ts
@@ -1,6 +1,10 @@
+import axios from "axios";
 import vnstock from "../src";
 
-describe("Listing", () => {
+const RUN_INTEGRATION = process.env.INTEGRATION === "1";
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+describeIntegration("Listing (integration — INTEGRATION=1)", () => {
   // Skipped: ai.vietcap.com.vn endpoint currently returns 403
   it.skip("should return all symbols", async () => {
     const data = await vnstock.stock.listing.allSymbols();
@@ -49,4 +53,60 @@ describe("Listing", () => {
     expect(data.length).toBeGreaterThan(0);
     expect(data[0]).toHaveProperty("symbol");
   }, 30000);
+});
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Listing (mocked)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAxios.request.mockResolvedValue({ data: {}, headers: {} });
+  });
+
+  it("symbolsByExchange normalizes board → exchange + organName → companyName", async () => {
+    mockedAxios.request.mockResolvedValue({
+      data: [
+        { symbol: "VCB", board: "HSX", organName: "Vietcombank", icbName3: "Ngân hàng", enIcbName3: "Banks" },
+      ],
+      headers: {},
+    });
+    const data = await vnstock.stock.listing.symbolsByExchange();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data[0]).toHaveProperty("symbol", "VCB");
+    expect(data[0]).toHaveProperty("exchange");
+    expect(data[0]).toHaveProperty("companyName");
+    expect(data[0]).not.toHaveProperty("board");
+    expect(data[0]).not.toHaveProperty("organName");
+  });
+
+  it("industriesIcb normalizes ICB code → code + viSector → name", async () => {
+    mockedAxios.request.mockResolvedValue({
+      data: {
+        data: [
+          { name: "0001", icbLevel: 1, viSector: "Năng lượng", enSector: "Oil & Gas" },
+          { name: "0500", icbLevel: 2, viSector: "Dầu khí", enSector: "Oil & Gas Producers" },
+        ],
+      },
+      headers: {},
+    });
+    const data = await vnstock.stock.listing.industriesIcb();
+    expect(data.length).toBe(2);
+    expect(data[0]).toHaveProperty("code", "0001");
+    expect(data[0]).toHaveProperty("name", "Năng lượng");
+    expect(data[0]).toHaveProperty("nameEn", "Oil & Gas");
+  });
+
+  it("symbolsByGroup normalizes raw VN30 list", async () => {
+    mockedAxios.request.mockResolvedValue({
+      data: [
+        { symbol: "VCB", board: "HSX", organName: "Vietcombank" },
+        { symbol: "FPT", board: "HSX", organName: "FPT Corp" },
+      ],
+      headers: {},
+    });
+    const data = await vnstock.stock.listing.symbolsByGroup("VN30");
+    expect(data.length).toBe(2);
+    expect(data[0].symbol).toBe("VCB");
+  });
 });

--- a/__tests__/pipeline/cloudflare-1015.test.ts
+++ b/__tests__/pipeline/cloudflare-1015.test.ts
@@ -1,0 +1,149 @@
+import axios from "axios";
+import { fetchWithRetry } from "../../src/pipeline/fetch";
+import { RateLimitError } from "../../src/errors";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe("Cloudflare Error 1015 detection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws RateLimitError when response body contains 'Error 1015' with cf-ray header", async () => {
+    const cfError = {
+      response: {
+        status: 429,
+        headers: { "cf-ray": "9fb94bc1d87008a2" },
+        data: "<html><body>Error 1015: You are being rate limited</body></html>",
+      },
+    };
+    mockedAxios.request.mockRejectedValue(cfError);
+
+    await expect(
+      fetchWithRetry(
+        { url: "https://api.vietcap.com.vn/test", method: "GET" },
+        { retries: 0, retryDelay: 10, rateLimitWait: 0 }
+      )
+    ).rejects.toThrow(RateLimitError);
+
+    await expect(
+      fetchWithRetry(
+        { url: "https://api.vietcap.com.vn/test", method: "GET" },
+        { retries: 0, retryDelay: 10, rateLimitWait: 0 }
+      )
+    ).rejects.toThrow(/Cloudflare Error 1015/);
+  });
+
+  it("throws RateLimitError on HTTP 403 with cloudflare body + cf-ray", async () => {
+    const cfError = {
+      response: {
+        status: 403,
+        headers: { "cf-ray": "deadbeef" },
+        data: "<html>Sorry, you have been blocked. Powered by cloudflare</html>",
+      },
+    };
+    mockedAxios.request.mockRejectedValue(cfError);
+
+    await expect(
+      fetchWithRetry(
+        { url: "https://api.vietcap.com.vn/test", method: "GET" },
+        { retries: 0, retryDelay: 10, rateLimitWait: 0 }
+      )
+    ).rejects.toThrow(RateLimitError);
+  });
+
+  it("does NOT mistake plain 429 (no cf-ray) for Cloudflare 1015", async () => {
+    const plain429 = {
+      response: {
+        status: 429,
+        headers: {},
+        data: "rate limited",
+      },
+    };
+    mockedAxios.request.mockRejectedValue(plain429);
+
+    await expect(
+      fetchWithRetry(
+        { url: "https://example.com/api", method: "GET" },
+        { retries: 0, retryDelay: 10, rateLimitWait: 0 }
+      )
+    ).rejects.toThrow(RateLimitError);
+  });
+
+  it("does NOT classify regular 403 (no cf-ray) as RateLimitError", async () => {
+    const plain403 = {
+      response: {
+        status: 403,
+        headers: {},
+        data: "forbidden",
+        statusText: "Forbidden",
+      },
+    };
+    mockedAxios.request.mockRejectedValue(plain403);
+
+    let thrown: any;
+    try {
+      await fetchWithRetry(
+        { url: "https://example.com/api", method: "GET" },
+        { retries: 0, retryDelay: 10, rateLimitWait: 0 }
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown).not.toBeInstanceOf(RateLimitError);
+  });
+
+  it("does NOT classify cf-ray + JSON body (non-1015) as Cloudflare 1015", async () => {
+    const cfApi = {
+      response: {
+        status: 500,
+        headers: { "cf-ray": "deadbeef" },
+        data: { error: "Internal" },
+        statusText: "Internal Server Error",
+      },
+    };
+    mockedAxios.request.mockRejectedValue(cfApi);
+
+    let thrown: any;
+    try {
+      await fetchWithRetry(
+        { url: "https://api.vietcap.com.vn/test", method: "GET" },
+        { retries: 0, retryDelay: 10, rateLimitWait: 0 }
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown).not.toBeInstanceOf(RateLimitError);
+  });
+
+  it("retries with exponential backoff on Cloudflare 1015 (fake timers)", async () => {
+    jest.useFakeTimers();
+    const cfError = {
+      response: {
+        status: 429,
+        headers: { "cf-ray": "abc123" },
+        data: "Error 1015",
+      },
+    };
+    mockedAxios.request
+      .mockRejectedValueOnce(cfError)
+      .mockResolvedValueOnce({ data: { ok: true } });
+
+    const promise = fetchWithRetry(
+      { url: "https://api.vietcap.com.vn/test", method: "GET" },
+      { retries: 1, retryDelay: 10, rateLimitWait: 0 }
+    );
+
+    // Advance through 30s wait (first attempt -> sleep -> retry)
+    await jest.advanceTimersByTimeAsync(30000);
+
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+    expect(mockedAxios.request).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+});

--- a/__tests__/vci-cache.test.ts
+++ b/__tests__/vci-cache.test.ts
@@ -1,0 +1,91 @@
+import axios from "axios";
+import { VciAdapter } from "../src/adapters/vci";
+
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Handshake is a module-level singleton — gets set true after first test. Mock it
+// generously so any handshake call still resolves, but don't assert its count.
+function setupMocks(icbData: any[] = [{ name: "01", icbLevel: 1, viSector: "X", enSector: "X" }]) {
+  mockedAxios.request.mockResolvedValue({
+    data: Array.isArray(icbData) ? { data: icbData } : icbData,
+    headers: {},
+  });
+}
+
+describe("VciAdapter TTL cache", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("fetchIndustriesIcb()", () => {
+    it("second call hits cache (no additional axios.request)", async () => {
+      const adapter = new VciAdapter();
+      setupMocks();
+      await adapter.fetchIndustriesIcb();
+      const callsAfterFirst = mockedAxios.request.mock.calls.length;
+      await adapter.fetchIndustriesIcb();
+      expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst);
+    });
+
+    it("opt-out via { cache: false } refetches every call", async () => {
+      const adapter = new VciAdapter({ cache: false });
+      setupMocks();
+      await adapter.fetchIndustriesIcb();
+      const callsAfterFirst = mockedAxios.request.mock.calls.length;
+      await adapter.fetchIndustriesIcb();
+      expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst + 1);
+    });
+  });
+
+  describe("fetchSymbolsByIndustries()", () => {
+    it("caches per language", async () => {
+      const adapter = new VciAdapter();
+      setupMocks([{ code: "VCB", name: "Vietcombank", icbLv1: {}, icbLv2: {}, icbLv3: {}, icbLv4: {} }]);
+      mockedAxios.request.mockResolvedValue({
+        data: [{ code: "VCB", name: "Vietcombank", icbLv1: {}, icbLv2: {}, icbLv3: {}, icbLv4: {} }],
+        headers: {},
+      });
+
+      await adapter.fetchSymbolsByIndustries("vi");
+      const callsAfterFirst = mockedAxios.request.mock.calls.length;
+      await adapter.fetchSymbolsByIndustries("vi");
+      expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst);
+
+      await adapter.fetchSymbolsByIndustries("en");
+      expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst + 1);
+
+      await adapter.fetchSymbolsByIndustries("en");
+      expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst + 1);
+    });
+  });
+
+  describe("clearCache()", () => {
+    it("forces refetch after clear", async () => {
+      const adapter = new VciAdapter();
+      setupMocks();
+      await adapter.fetchIndustriesIcb();
+      const callsAfterFirst = mockedAxios.request.mock.calls.length;
+      adapter.clearCache();
+      await adapter.fetchIndustriesIcb();
+      expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst + 1);
+    });
+  });
+
+  describe("TTL expiration", () => {
+    it("refetches after entry expires", async () => {
+      jest.useFakeTimers();
+      try {
+        const adapter = new VciAdapter();
+        setupMocks();
+        await adapter.fetchIndustriesIcb();
+        const callsAfterFirst = mockedAxios.request.mock.calls.length;
+        jest.setSystemTime(Date.now() + 61 * 60 * 1000);
+        await adapter.fetchIndustriesIcb();
+        expect(mockedAxios.request.mock.calls.length).toBe(callsAfterFirst + 1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vnstock-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/adapters/vci.ts
+++ b/src/adapters/vci.ts
@@ -77,8 +77,60 @@ function tsToDate(ts: number | string | null | undefined): string {
   return d.toISOString().substring(0, 10);
 }
 
+export interface VciAdapterOptions {
+  cache?: boolean;
+}
+
+interface CacheEntry {
+  data: any;
+  expiresAt: number;
+}
+
+const CACHE_TTL_METRICS = 60 * 60 * 1000;
+const CACHE_TTL_ICB = 60 * 60 * 1000;
+const CACHE_TTL_SEARCH_BAR = 30 * 60 * 1000;
+
 export class VciAdapter implements StockDataAdapter {
   readonly name = "VCI";
+
+  private cacheEnabled: boolean;
+  private cache: Map<string, CacheEntry> = new Map();
+
+  constructor(options: VciAdapterOptions = {}) {
+    this.cacheEnabled = options.cache !== false;
+  }
+
+  private cacheGet(key: string): any | undefined {
+    if (!this.cacheEnabled) return undefined;
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    return entry.data;
+  }
+
+  private cacheSet(key: string, data: any, ttlMs: number): void {
+    if (!this.cacheEnabled) return;
+    this.cache.set(key, { data, expiresAt: Date.now() + ttlMs });
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  private async fetchMetricsCached(symbol: string): Promise<any> {
+    const cacheKey = `metrics:${symbol}`;
+    const cached = this.cacheGet(cacheKey);
+    if (cached !== undefined) return cached;
+    const fresh = await fetchWithRetry<any>({
+      url: `${VCI_COMPANY_URL}/${symbol}/financial-statement/metrics`,
+      method: "GET",
+    }).catch(() => null);
+    if (fresh !== null) this.cacheSet(cacheKey, fresh, CACHE_TTL_METRICS);
+    return fresh;
+  }
 
   private async ensureHandshake(): Promise<void> {
     if (handshakeDone) return;
@@ -208,11 +260,16 @@ export class VciAdapter implements StockDataAdapter {
   async fetchSymbolsByIndustries(lang: string = "vi"): Promise<IndustryInfo[]> {
     await this.ensureHandshake();
     const language = lang === "en" ? 2 : 1;
-    const response = await fetchWithRetry<any>({
-      url: `${VCI_IQ_URL}/v2/company/search-bar`,
-      method: "GET",
-      params: { language },
-    });
+    const cacheKey = `search-bar:${language}`;
+    let response = this.cacheGet(cacheKey);
+    if (response === undefined) {
+      response = await fetchWithRetry<any>({
+        url: `${VCI_IQ_URL}/v2/company/search-bar`,
+        method: "GET",
+        params: { language },
+      });
+      this.cacheSet(cacheKey, response, CACHE_TTL_SEARCH_BAR);
+    }
 
     const items: any[] = Array.isArray(response) ? response : (response && response.data) || [];
     return items.map((t: any) => {
@@ -241,10 +298,15 @@ export class VciAdapter implements StockDataAdapter {
 
   async fetchIndustriesIcb(): Promise<IndustryClassification[]> {
     await this.ensureHandshake();
-    const response = await fetchWithRetry<any>({
-      url: `${VCI_IQ_URL}/v1/sectors/icb-codes`,
-      method: "GET",
-    });
+    const cacheKey = "icb-codes";
+    let response = this.cacheGet(cacheKey);
+    if (response === undefined) {
+      response = await fetchWithRetry<any>({
+        url: `${VCI_IQ_URL}/v1/sectors/icb-codes`,
+        method: "GET",
+      });
+      this.cacheSet(cacheKey, response, CACHE_TTL_ICB);
+    }
 
     const items: any[] = Array.isArray(response) ? response : (response && response.data) || [];
     return items.map((i: any) => ({
@@ -293,10 +355,7 @@ export class VciAdapter implements StockDataAdapter {
         method: "GET",
         params: { period: periodCode },
       }).catch(() => null),
-      fetchWithRetry<any>({
-        url: `${VCI_COMPANY_URL}/${symbol}/financial-statement/metrics`,
-        method: "GET",
-      }).catch(() => null),
+      this.fetchMetricsCached(symbol),
     ]);
 
     const statementData = (statementResp && statementResp.data) || null;

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -121,7 +121,7 @@ export const tools: ToolSchema[] = [
     name: "get_ai_context",
     description:
       "Lấy bối cảnh phân tích kỹ thuật cho 1 mã, dạng structured JSON. " +
-      "Bao gồm trend (bullish/bearish/neutral), indicators (RSI, MACD, SMA20/50/200, ATR, Bollinger), " +
+      "Bao gồm trend (bullish/bearish/neutral), indicators (RSI, MACD, SMA20/50/200, EMA, ATR, Bollinger, SuperTrend, Ichimoku Cloud), " +
       "support/resistance pivot, volume signal, %change 1d/7d/30d/90d. " +
       "Dùng khi user hỏi 'phân tích kỹ thuật VCB', 'VCB đang xu hướng gì'. " +
       "EN: Get pre-computed technical analysis context for a Vietnam stock symbol.",
@@ -138,6 +138,7 @@ export const tools: ToolSchema[] = [
     name: "to_ai_prompt",
     description:
       "Tương tự get_ai_context nhưng trả plain-text format optimize cho LLM context window. " +
+      "Include: trend, RSI, MACD, SMA/EMA, ATR, Bollinger, SuperTrend, Ichimoku Cloud, support/resistance, volume, performance. " +
       "Dùng khi user export context để dán vào GPT/Gemini bên ngoài. " +
       "EN: Same as get_ai_context but returns plain-text formatted for LLM context window.",
     inputSchema: {

--- a/src/core/commodity/gold.ts
+++ b/src/core/commodity/gold.ts
@@ -35,7 +35,18 @@ export class GoldService {
     return rawData?.data || rawData || [];
   }
 
+  /**
+   * @deprecated Since v1.4.1. SJC endpoint returns HTTP 403 from non-Vietnam IPs
+   *             (Cloudflare/WAF block). Use `goldPriceBTMC()` or `goldPriceGiaVangNet()` instead.
+   *             Method retained for backwards compat; may be removed in v2.0.
+   */
   async goldPriceSJC(): Promise<GoldPriceSjc[]> {
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        "[vnstock-js] goldPriceSJC() is deprecated: SJC endpoint returns 403 from non-VN IPs. " +
+        "Use goldPriceBTMC() or goldPriceGiaVangNet() instead."
+      );
+    }
     const rawData = await fetchWithRetry<any>({
       url: "https://sjc.com.vn/GoldPrice/Services/PriceService.ashx",
       method: "GET",

--- a/src/core/stock/ai-context.ts
+++ b/src/core/stock/ai-context.ts
@@ -106,6 +106,19 @@ export function classifyTrend(data: QuoteHistory[]): TrendInfo {
     return { direction: "neutral", strength: 0, rationale: "Không đủ dữ liệu indicator" };
   }
 
+  const stLast = superTrend(data);
+  const stDir = stLast.length > 0 ? stLast[stLast.length - 1].direction : null;
+
+  const ichiSeries = ichimoku(data);
+  const lastIchi = ichiSeries.length > 0 ? ichiSeries[ichiSeries.length - 1] : null;
+  const lastClose = data[data.length - 1].close;
+  let priceVsCloud: "above" | "below" | "inside" | null = null;
+  if (lastIchi && lastIchi.cloudTop !== null && lastIchi.cloudBottom !== null) {
+    if (lastClose > lastIchi.cloudTop) priceVsCloud = "above";
+    else if (lastClose < lastIchi.cloudBottom) priceVsCloud = "below";
+    else priceVsCloud = "inside";
+  }
+
   let direction: "bullish" | "bearish" | "neutral";
   let rationale: string;
   let strength = 0;
@@ -122,6 +135,47 @@ export function classifyTrend(data: QuoteHistory[]): TrendInfo {
     direction = "neutral";
     rationale = "EMA chuỗi không nhất quán hoặc slope flat — sideway";
     strength = 0.3;
+  }
+
+  if (stDir !== null || priceVsCloud !== null) {
+    const stBull = stDir === "bullish";
+    const stBear = stDir === "bearish";
+    const cloudBull = priceVsCloud === "above";
+    const cloudBear = priceVsCloud === "below";
+
+    if (direction === "bullish") {
+      if (stBull && cloudBull) {
+        strength = Math.min(1, strength + 0.2);
+        rationale += " · ST + Ichimoku confirm bullish";
+      } else if (stBear && cloudBear) {
+        strength = strength * 0.5;
+        rationale += " · ST + Ichimoku contradict (bearish)";
+      } else if (stBear || cloudBear) {
+        strength = strength * 0.8;
+        rationale += " · ST/Ichimoku mixed";
+      }
+    } else if (direction === "bearish") {
+      if (stBear && cloudBear) {
+        strength = Math.min(1, strength + 0.2);
+        rationale += " · ST + Ichimoku confirm bearish";
+      } else if (stBull && cloudBull) {
+        strength = strength * 0.5;
+        rationale += " · ST + Ichimoku contradict (bullish)";
+      } else if (stBull || cloudBull) {
+        strength = strength * 0.8;
+        rationale += " · ST/Ichimoku mixed";
+      }
+    } else {
+      if (stBull && cloudBull) {
+        direction = "bullish";
+        strength = 0.4;
+        rationale = "EMA flat nhưng ST + Ichimoku đồng thuận bullish";
+      } else if (stBear && cloudBear) {
+        direction = "bearish";
+        strength = 0.4;
+        rationale = "EMA flat nhưng ST + Ichimoku đồng thuận bearish";
+      }
+    }
   }
 
   return { direction, strength, rationale };

--- a/src/core/stock/ai-context.ts
+++ b/src/core/stock/ai-context.ts
@@ -6,6 +6,8 @@ import { rsi } from "../../indicators/rsi";
 import { macd } from "../../indicators/macd";
 import { bollinger } from "../../indicators/bollinger";
 import { atr } from "../../indicators/atr";
+import { superTrend } from "../../indicators/supertrend";
+import { ichimoku } from "../../indicators/ichimoku";
 import { detectPivots, PivotLevels } from "./pivot";
 
 export interface TrendInfo {
@@ -21,6 +23,18 @@ export interface IndicatorSnapshot {
   ema: { 20: number | null; 50: number | null; 200: number | null };
   bollinger: { upper: number | null; middle: number | null; lower: number | null; percentB: number | null };
   atr14: number | null;
+  superTrend: {
+    value: number | null;
+    direction: "bullish" | "bearish" | null;
+  };
+  ichimoku: {
+    tenkanSen: number | null;
+    kijunSen: number | null;
+    cloudTop: number | null;
+    cloudBottom: number | null;
+    priceVsCloud: "above" | "below" | "inside" | null;
+    tkCross: "bullish" | "bearish" | "none";
+  };
 }
 
 export interface VolumeInfo {
@@ -131,6 +145,31 @@ export function snapshotIndicators(data: QuoteHistory[]): IndicatorSnapshot {
   const lastBoll = bollSeries.length > 0 ? bollSeries[bollSeries.length - 1] : null;
   const lastAtr = atrSeries.length > 0 ? atrSeries[atrSeries.length - 1].atr : null;
 
+  const stSeries = superTrend(data);
+  const lastST = stSeries.length > 0 ? stSeries[stSeries.length - 1] : null;
+
+  const ichiSeries = ichimoku(data);
+  const lastIchi = ichiSeries.length > 0 ? ichiSeries[ichiSeries.length - 1] : null;
+  const prevIchi = ichiSeries.length > 1 ? ichiSeries[ichiSeries.length - 2] : null;
+
+  const lastClose = data.length > 0 ? data[data.length - 1].close : null;
+  let priceVsCloud: "above" | "below" | "inside" | null = null;
+  if (lastClose !== null && lastIchi && lastIchi.cloudTop !== null && lastIchi.cloudBottom !== null) {
+    if (lastClose > lastIchi.cloudTop) priceVsCloud = "above";
+    else if (lastClose < lastIchi.cloudBottom) priceVsCloud = "below";
+    else priceVsCloud = "inside";
+  }
+
+  let tkCross: "bullish" | "bearish" | "none" = "none";
+  if (
+    lastIchi && prevIchi &&
+    lastIchi.tenkanSen !== null && lastIchi.kijunSen !== null &&
+    prevIchi.tenkanSen !== null && prevIchi.kijunSen !== null
+  ) {
+    if (lastIchi.tenkanSen > lastIchi.kijunSen && prevIchi.tenkanSen <= prevIchi.kijunSen) tkCross = "bullish";
+    else if (lastIchi.tenkanSen < lastIchi.kijunSen && prevIchi.tenkanSen >= prevIchi.kijunSen) tkCross = "bearish";
+  }
+
   let crossover: "bullish" | "bearish" | "none" = "none";
   if (lastMacd && prevMacd && lastMacd.histogram !== null && prevMacd.histogram !== null) {
     if (prevMacd.histogram <= 0 && lastMacd.histogram > 0) crossover = "bullish";
@@ -154,6 +193,18 @@ export function snapshotIndicators(data: QuoteHistory[]): IndicatorSnapshot {
       percentB: lastBoll?.percentB ?? null,
     },
     atr14: lastAtr,
+    superTrend: {
+      value: lastST ? lastST.superTrend : null,
+      direction: lastST ? lastST.direction : null,
+    },
+    ichimoku: {
+      tenkanSen: lastIchi ? lastIchi.tenkanSen : null,
+      kijunSen: lastIchi ? lastIchi.kijunSen : null,
+      cloudTop: lastIchi ? lastIchi.cloudTop : null,
+      cloudBottom: lastIchi ? lastIchi.cloudBottom : null,
+      priceVsCloud,
+      tkCross,
+    },
   };
 }
 
@@ -240,6 +291,18 @@ export function formatAIPrompt(ctx: AIContext, lang: "vi" | "en" = "vi"): string
     lines.push(`EMA: 20=${ind.ema[20]?.toFixed(2) ?? "n/a"}, 50=${ind.ema[50]?.toFixed(2) ?? "n/a"}, 200=${ind.ema[200]?.toFixed(2) ?? "n/a"}`);
     lines.push(`Bollinger %B: ${ind.bollinger.percentB?.toFixed(2) ?? "n/a"} (upper=${ind.bollinger.upper?.toFixed(2) ?? "n/a"}, lower=${ind.bollinger.lower?.toFixed(2) ?? "n/a"})`);
     lines.push(`ATR(14): ${ind.atr14?.toFixed(3) ?? "n/a"}`);
+    const stVi = ind.superTrend;
+    const stArrowVi = stVi.direction === "bullish" ? "▲ TĂNG" : stVi.direction === "bearish" ? "▼ GIẢM" : "n/a";
+    lines.push(`SuperTrend: ${stVi.value?.toFixed(2) ?? "n/a"} (${stArrowVi})`);
+    const ichiVi = ind.ichimoku;
+    const cloudStrVi = ichiVi.cloudBottom !== null && ichiVi.cloudTop !== null
+      ? `[${ichiVi.cloudBottom.toFixed(2)} – ${ichiVi.cloudTop.toFixed(2)}]`
+      : "n/a";
+    const priceVsVi = ichiVi.priceVsCloud === "above" ? "TRÊN mây"
+                    : ichiVi.priceVsCloud === "below" ? "DƯỚI mây"
+                    : ichiVi.priceVsCloud === "inside" ? "TRONG mây"
+                    : "n/a";
+    lines.push(`Ichimoku: TK ${ichiVi.tenkanSen?.toFixed(2) ?? "n/a"} / KJ ${ichiVi.kijunSen?.toFixed(2) ?? "n/a"} · Cloud ${cloudStrVi} · Giá ${priceVsVi} · TK cross: ${ichiVi.tkCross}`);
     lines.push(`Volume: ${ctx.volume.today.toLocaleString()} (avg ${ctx.volume.avg20.toLocaleString()}, z-score ${ctx.volume.zscore.toFixed(2)}, ${ctx.volume.signal})`);
     lines.push(`Support: ${ctx.levels.support.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
     lines.push(`Resistance: ${ctx.levels.resistance.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
@@ -255,6 +318,13 @@ export function formatAIPrompt(ctx: AIContext, lang: "vi" | "en" = "vi"): string
     lines.push(`SMA: 20=${ind.sma[20]?.toFixed(2) ?? "n/a"}, 50=${ind.sma[50]?.toFixed(2) ?? "n/a"}, 200=${ind.sma[200]?.toFixed(2) ?? "n/a"}`);
     lines.push(`Bollinger %B: ${ind.bollinger.percentB?.toFixed(2) ?? "n/a"}`);
     lines.push(`ATR(14): ${ind.atr14?.toFixed(3) ?? "n/a"}`);
+    const stEn = ind.superTrend;
+    lines.push(`SuperTrend: ${stEn.value?.toFixed(2) ?? "n/a"} (${stEn.direction ?? "n/a"})`);
+    const ichiEn = ind.ichimoku;
+    const cloudStrEn = ichiEn.cloudBottom !== null && ichiEn.cloudTop !== null
+      ? `[${ichiEn.cloudBottom.toFixed(2)} – ${ichiEn.cloudTop.toFixed(2)}]`
+      : "n/a";
+    lines.push(`Ichimoku: TK ${ichiEn.tenkanSen?.toFixed(2) ?? "n/a"} / KJ ${ichiEn.kijunSen?.toFixed(2) ?? "n/a"} · Cloud ${cloudStrEn} · Price ${ichiEn.priceVsCloud ?? "n/a"} cloud · TK cross: ${ichiEn.tkCross}`);
     lines.push(`Volume: ${ctx.volume.today} (z-score ${ctx.volume.zscore.toFixed(2)}, ${ctx.volume.signal})`);
     lines.push(`Support: ${ctx.levels.support.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);
     lines.push(`Resistance: ${ctx.levels.resistance.map((v) => v.toFixed(2)).join(" / ") || "n/a"}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export const realtime = { create: createRealtime, parseData };
 export { RealtimeClient };
 export { Vnstock };
 export { init };
-export { sma, ema, rsi } from "./indicators";
+export { sma, ema, rsi, superTrend, ichimoku } from "./indicators";
 
 export type { ScreenFilter, ScreenOptions, ScreenResult } from "./models/screening";
 export type { StockDataAdapter } from "./adapters/types";

--- a/src/indicators/ichimoku.ts
+++ b/src/indicators/ichimoku.ts
@@ -1,0 +1,94 @@
+import { QuoteHistory } from "../models/normalized";
+
+export interface IchimokuOptions {
+  tenkan?: number;
+  kijun?: number;
+  senkou?: number;
+  displacement?: number;
+}
+
+export interface IchimokuResult {
+  date: string;
+  tenkanSen: number | null;
+  kijunSen: number | null;
+  senkouSpanA: number | null;
+  senkouSpanB: number | null;
+  chikouSpan: number | null;
+  cloudTop: number | null;
+  cloudBottom: number | null;
+}
+
+function donchian(data: QuoteHistory[], end: number, period: number): number | null {
+  if (end + 1 < period) return null;
+  var hi = -Infinity;
+  var lo = Infinity;
+  for (var j = end - period + 1; j <= end; j++) {
+    if (data[j].high > hi) hi = data[j].high;
+    if (data[j].low < lo) lo = data[j].low;
+  }
+  return (hi + lo) / 2;
+}
+
+export function ichimoku(
+  data: QuoteHistory[],
+  options: IchimokuOptions = {}
+): IchimokuResult[] {
+  var tenkanP = options.tenkan == null ? 9 : options.tenkan;
+  var kijunP = options.kijun == null ? 26 : options.kijun;
+  var senkouP = options.senkou == null ? 52 : options.senkou;
+  var displacement = options.displacement == null ? 26 : options.displacement;
+
+  if (tenkanP < 1 || kijunP < 1 || senkouP < 1 || displacement < 1) {
+    throw new Error("Period must be >= 1");
+  }
+  if (data.length === 0) return [];
+
+  var n = data.length;
+  var results: IchimokuResult[] = new Array(n);
+
+  var tenkanArr: (number | null)[] = new Array(n);
+  var kijunArr: (number | null)[] = new Array(n);
+  var senkouBRawArr: (number | null)[] = new Array(n);
+
+  for (var i = 0; i < n; i++) {
+    tenkanArr[i] = donchian(data, i, tenkanP);
+    kijunArr[i] = donchian(data, i, kijunP);
+    senkouBRawArr[i] = donchian(data, i, senkouP);
+  }
+
+  for (var k = 0; k < n; k++) {
+    var src = k - displacement;
+    var spanA: number | null = null;
+    var spanB: number | null = null;
+    if (src >= 0) {
+      var t = tenkanArr[src];
+      var kj = kijunArr[src];
+      if (t !== null && kj !== null) spanA = (t + kj) / 2;
+      spanB = senkouBRawArr[src];
+    }
+
+    var chikou: number | null = null;
+    var chikouIdx = k + displacement;
+    if (chikouIdx < n) chikou = data[chikouIdx].close;
+
+    var top: number | null = null;
+    var bot: number | null = null;
+    if (spanA !== null && spanB !== null) {
+      top = spanA > spanB ? spanA : spanB;
+      bot = spanA < spanB ? spanA : spanB;
+    }
+
+    results[k] = {
+      date: data[k].date,
+      tenkanSen: tenkanArr[k],
+      kijunSen: kijunArr[k],
+      senkouSpanA: spanA,
+      senkouSpanB: spanB,
+      chikouSpan: chikou,
+      cloudTop: top,
+      cloudBottom: bot,
+    };
+  }
+
+  return results;
+}

--- a/src/indicators/ichimoku.ts
+++ b/src/indicators/ichimoku.ts
@@ -18,6 +18,14 @@ export interface IchimokuResult {
   cloudBottom: number | null;
 }
 
+export interface IchimokuFutureBar {
+  offset: number;
+  senkouSpanA: number;
+  senkouSpanB: number;
+  cloudTop: number;
+  cloudBottom: number;
+}
+
 function donchian(data: QuoteHistory[], end: number, period: number): number | null {
   if (end + 1 < period) return null;
   var hi = -Infinity;
@@ -91,4 +99,41 @@ export function ichimoku(
   }
 
   return results;
+}
+
+export function ichimokuFutureCloud(
+  data: QuoteHistory[],
+  options: IchimokuOptions = {}
+): IchimokuFutureBar[] {
+  var tenkanP = options.tenkan == null ? 9 : options.tenkan;
+  var kijunP = options.kijun == null ? 26 : options.kijun;
+  var senkouP = options.senkou == null ? 52 : options.senkou;
+  var displacement = options.displacement == null ? 26 : options.displacement;
+
+  if (tenkanP < 1 || kijunP < 1 || senkouP < 1 || displacement < 1) {
+    throw new Error("Period must be >= 1");
+  }
+  if (data.length === 0) return [];
+
+  var n = data.length;
+  var future: IchimokuFutureBar[] = [];
+
+  for (var k = 1; k <= displacement; k++) {
+    var src = n - 1 - displacement + k;
+    if (src < 0) continue;
+    var tenkanVal = donchian(data, src, tenkanP);
+    var kijunVal = donchian(data, src, kijunP);
+    var spanBVal = donchian(data, src, senkouP);
+    if (tenkanVal === null || kijunVal === null || spanBVal === null) continue;
+    var spanA = (tenkanVal + kijunVal) / 2;
+    future.push({
+      offset: k,
+      senkouSpanA: spanA,
+      senkouSpanB: spanBVal,
+      cloudTop: spanA > spanBVal ? spanA : spanBVal,
+      cloudBottom: spanA < spanBVal ? spanA : spanBVal,
+    });
+  }
+
+  return future;
 }

--- a/src/indicators/index.ts
+++ b/src/indicators/index.ts
@@ -5,4 +5,4 @@ export { macd, type MacdResult } from "./macd";
 export { bollinger, type BollingerResult } from "./bollinger";
 export { atr, type AtrResult } from "./atr";
 export { superTrend, type SuperTrendResult, type SuperTrendOptions } from "./supertrend";
-export { ichimoku, type IchimokuResult, type IchimokuOptions } from "./ichimoku";
+export { ichimoku, ichimokuFutureCloud, type IchimokuResult, type IchimokuOptions, type IchimokuFutureBar } from "./ichimoku";

--- a/src/indicators/index.ts
+++ b/src/indicators/index.ts
@@ -4,3 +4,5 @@ export { rsi, type RsiResult } from "./rsi";
 export { macd, type MacdResult } from "./macd";
 export { bollinger, type BollingerResult } from "./bollinger";
 export { atr, type AtrResult } from "./atr";
+export { superTrend, type SuperTrendResult, type SuperTrendOptions } from "./supertrend";
+export { ichimoku, type IchimokuResult, type IchimokuOptions } from "./ichimoku";

--- a/src/indicators/supertrend.ts
+++ b/src/indicators/supertrend.ts
@@ -1,0 +1,119 @@
+import { QuoteHistory } from "../models/normalized";
+import { atr } from "./atr";
+
+export interface SuperTrendOptions {
+  period?: number;
+  multiplier?: number;
+}
+
+export interface SuperTrendResult {
+  date: string;
+  superTrend: number | null;
+  direction: "bullish" | "bearish" | null;
+  upperBand: number | null;
+  lowerBand: number | null;
+}
+
+export function superTrend(
+  data: QuoteHistory[],
+  options: SuperTrendOptions = {}
+): SuperTrendResult[] {
+  var period = options.period == null ? 10 : options.period;
+  var multiplier = options.multiplier == null ? 3 : options.multiplier;
+
+  if (period < 1) throw new Error("Period must be >= 1");
+  if (multiplier <= 0) throw new Error("Multiplier must be > 0");
+  if (data.length === 0) return [];
+
+  var atrSeries = atr(data, period);
+
+  var results: SuperTrendResult[] = new Array(data.length);
+  var prevFinalUpper = 0;
+  var prevFinalLower = 0;
+  var prevSuperTrend = 0;
+  var prevWasUpper = true;
+  var initialized = false;
+
+  for (var i = 0; i < data.length; i++) {
+    var bar = data[i];
+    var atrVal = atrSeries[i].atr;
+
+    if (atrVal === null) {
+      results[i] = {
+        date: bar.date,
+        superTrend: null,
+        direction: null,
+        upperBand: null,
+        lowerBand: null,
+      };
+      continue;
+    }
+
+    var hl2 = (bar.high + bar.low) / 2;
+    var basicUpper = hl2 + multiplier * atrVal;
+    var basicLower = hl2 - multiplier * atrVal;
+
+    var finalUpper: number;
+    var finalLower: number;
+    if (!initialized) {
+      finalUpper = basicUpper;
+      finalLower = basicLower;
+    } else {
+      var prevClose = data[i - 1].close;
+      finalUpper =
+        basicUpper < prevFinalUpper || prevClose > prevFinalUpper
+          ? basicUpper
+          : prevFinalUpper;
+      finalLower =
+        basicLower > prevFinalLower || prevClose < prevFinalLower
+          ? basicLower
+          : prevFinalLower;
+    }
+
+    var st: number;
+    var dir: "bullish" | "bearish";
+    if (!initialized) {
+      if (bar.close <= finalUpper) {
+        st = finalUpper;
+        prevWasUpper = true;
+      } else {
+        st = finalLower;
+        prevWasUpper = false;
+      }
+    } else {
+      if (prevWasUpper) {
+        if (bar.close <= finalUpper) {
+          st = finalUpper;
+          prevWasUpper = true;
+        } else {
+          st = finalLower;
+          prevWasUpper = false;
+        }
+      } else {
+        if (bar.close >= finalLower) {
+          st = finalLower;
+          prevWasUpper = false;
+        } else {
+          st = finalUpper;
+          prevWasUpper = true;
+        }
+      }
+    }
+    dir = bar.close > st ? "bullish" : "bearish";
+
+    results[i] = {
+      date: bar.date,
+      superTrend: st,
+      direction: dir,
+      upperBand: finalUpper,
+      lowerBand: finalLower,
+    };
+
+    prevFinalUpper = finalUpper;
+    prevFinalLower = finalLower;
+    prevSuperTrend = st;
+    initialized = true;
+  }
+
+  return results;
+}

--- a/src/pipeline/fetch.ts
+++ b/src/pipeline/fetch.ts
@@ -10,12 +10,27 @@ function isRetryable(error: any): boolean {
   return false;
 }
 
+function isCloudflareRateLimit(error: any): boolean {
+  if (!error.response) return false;
+  var headers = error.response.headers || {};
+  var hasCfRay = !!(headers["cf-ray"] || headers["CF-RAY"]);
+  if (!hasCfRay) return false;
+  var body = error.response.data;
+  if (typeof body !== "string") return false;
+  if (body.indexOf("Error 1015") !== -1) return true;
+  if (body.indexOf("cloudflare") !== -1 && error.response.status >= 400) return true;
+  return false;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function wrapError(error: any): never {
   if (error.response) {
+    if (isCloudflareRateLimit(error)) {
+      throw new RateLimitError("Cloudflare Error 1015 (rate limited)", error);
+    }
     const status: number = error.response.status;
     if (status === 429) {
       throw new RateLimitError(undefined, error);
@@ -81,6 +96,11 @@ export async function fetchWithRetry<T = unknown>(
         var retryAfter = parseInt(error.response.headers && error.response.headers["retry-after"], 10);
         var waitMs = retryAfter > 0 ? Math.min(retryAfter * 1000, rateLimitWait) : rateLimitWait;
         await sleep(waitMs);
+        continue;
+      }
+      if (isCloudflareRateLimit(error) && attempt < retries) {
+        var cfWait = 30000 * Math.pow(2, attempt);
+        await sleep(cfWait);
         continue;
       }
       if (attempt < retries && isRetryable(error)) {


### PR DESCRIPTION
## Summary

v1.4.1 patch release, bundle 3 chủ đề:

- **Indicators expansion** — `superTrend` + `ichimoku` (+ `ichimokuFutureCloud`), tích hợp vào `aiContext`/`toAIPrompt` và MCP tool descriptions. `classifyTrend()` được boost/penalize bởi SuperTrend + Ichimoku.
- **Network resilience** — detect Cloudflare Error 1015 (cf-ray + body match) → `RateLimitError` với exp backoff 30/60/120s. Deprecate `goldPriceSJC()` (console.warn redirect sang BTMC).
- **Stability** — TTL in-memory cache cho VCI `icb-codes` (1h) / `search-bar` (30min) / `metrics` (1h, per-symbol). Tests `listing`/`company`/`financial` gate sau `INTEGRATION=1` env, default mock-based.

Closes #9, #10, #11, #12.

## Commits

- `f9b7c5d` feat: v1.4.1 — Indicators expansion + network resilience
- `559a356` feat: v1.4.1 add — TTL cache + INTEGRATION gate + future cloud + trend boost

(Squash khi merge thành 1 commit v1.4.1 theo convention.)

## Tests

- 45 test suites pass, 383 tests pass / 18 skip / 0 fail
- New tests: 12 supertrend + 22 ichimoku (incl. 6 futureCloud) + 6 cloudflare-1015 + 5 vci-cache + 11 mock-based listing/company/financial + 2 classifyTrend boost assertions
- Run `INTEGRATION=1 npm test` để chạy real-API tests

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — full suite pass
- [ ] Smoke test MCP `get_ai_context` output bao gồm SuperTrend + Ichimoku
- [ ] Smoke test `vnstock.stock.aiContext('VCB')` từ npm pack tarball

## Migration notes

- Không breaking. `aiContext` JSON nay thêm 2 field (`superTrend`, `ichimoku`); ~200 bytes mỗi response.
- `VciAdapter` default bật cache. Code cũ phụ thuộc fresh API mỗi call cho metrics/ICB/search-bar: pass `{ cache: false }` hoặc gọi `clearCache()`.
- Tests cần real-API verification: `INTEGRATION=1 npm test`.