### PR TITLE
feat: v1.4.2 - dividend MCP tools + indicator export backfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,5 @@ CLAUDE.md
 .claude/
 .mcp.json
 docs/plans/
+docs/release/
 docs/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.4.2 — Dividend MCP Tools + Indicator Export Fix
+
+Patch thuần additive, không breaking. Expose lịch cổ tức/sự kiện doanh nghiệp qua MCP và backfill root export cho indicators v2.
+
+### Thêm
+
+- **MCP tool `get_dividends`** — wrap `company(symbol).dividends()`. Trả lịch sử & lịch chia cổ tức (tiền mặt + cổ phiếu): `eventType`, `ratio`, `value`, `exRightDate` (GDKHQ), `recordDate`. Daily-report pipeline qua MCP nay thấy được lịch cổ tức (vd. ACB) thay vì mù.
+- **MCP tool `get_corporate_events`** — wrap `company(symbol).events()`. Trả tất cả sự kiện doanh nghiệp (cổ tức, ĐHCĐ, phát hành, niêm yết, giao dịch nội bộ).
+- MCP server nay đăng ký **13 tools** (trước 11). Cả 2 tool bilingual (Vi + En).
+
+### Sửa
+
+- **Root export thiếu `macd` / `bollinger` / `atr`** — 3 indicator v2 đã có trong `src/indicators/index.ts` từ v1.4.0 nhưng `src/index.ts` quên re-export, buộc user import từ `vnstock-js/dist/indicators/*`. Nay export thẳng từ root: `import { macd, bollinger, atr } from "vnstock-js"`. Bổ sung luôn `ichimokuFutureCloud`. Fix này cũng làm đúng ví dụ import trong docs indicators (vốn đã ghi import từ root nhưng trước đó chạy lỗi).
+
+### Nội bộ
+
+- +5 test MCP handler (get_dividends + get_corporate_events). Schema test 11 → 13 tools.
+
+### Migration notes
+
+- Không breaking. Nếu trước đây import `macd`/`bollinger`/`atr` từ subpath `vnstock-js/dist/indicators/*`, vẫn chạy; nay có thể chuyển sang root import.
+
 ## 1.4.1 — Indicators Expansion + Network Resilience + Stability
 
 Bổ sung 2 indicator mới (SuperTrend + Ichimoku Cloud), gia tăng độ ổn định khi gặp Cloudflare rate-limit, deprecate endpoint SJC bị 403, gate integration tests sau env `INTEGRATION=1`, TTL cache cho VCI static endpoints.

--- a/__tests__/cli/mcp/handlers.test.ts
+++ b/__tests__/cli/mcp/handlers.test.ts
@@ -13,6 +13,7 @@ jest.mock("../../../src/runtime", () => {
     },
     aiContext: jest.fn(),
     toAIPrompt: jest.fn(),
+    company: jest.fn(),
     adapter: mockAdapter,
   };
   return {
@@ -169,6 +170,56 @@ describe("MCP handlers — group A (basic data tools)", () => {
       });
       const res = await handlers.get_company_info({ symbol: "VCB" });
       expect(res.isError).toBeUndefined();
+    });
+  });
+
+  describe("get_dividends", () => {
+    it("returns error if symbol missing", async () => {
+      const res = await handlers.get_dividends({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns dividend events via company().dividends()", async () => {
+      const dividendsFn = jest.fn().mockResolvedValueOnce([
+        { eventType: "DIVIDEND_CASH", ratio: 0.1, exRightDate: "2026-06-20", recordDate: "2026-06-23" },
+      ]);
+      stockMock.company.mockReturnValueOnce({ dividends: dividendsFn });
+      const res = await handlers.get_dividends({ symbol: "acb" });
+      expect(res.isError).toBeUndefined();
+      expect(stockMock.company).toHaveBeenCalledWith("ACB");
+      expect(dividendsFn).toHaveBeenCalled();
+      expect(res.content[0].text).toContain("ACB");
+      const data = JSON.parse(res.content[1].text);
+      expect(data.length).toBe(1);
+    });
+
+    it("returns error response when company call throws", async () => {
+      stockMock.company.mockReturnValueOnce({
+        dividends: jest.fn().mockRejectedValueOnce(new Error("boom")),
+      });
+      const res = await handlers.get_dividends({ symbol: "ACB" });
+      expect(res.isError).toBe(true);
+      expect(res.content[0].text).toContain("boom");
+    });
+  });
+
+  describe("get_corporate_events", () => {
+    it("returns error if symbol missing", async () => {
+      const res = await handlers.get_corporate_events({});
+      expect(res.isError).toBe(true);
+    });
+
+    it("returns all events via company().events()", async () => {
+      const eventsFn = jest.fn().mockResolvedValueOnce([
+        { eventType: "AGM", title: "ĐHCĐ 2026" },
+        { eventType: "DIVIDEND_STOCK", ratio: 0.15 },
+      ]);
+      stockMock.company.mockReturnValueOnce({ events: eventsFn });
+      const res = await handlers.get_corporate_events({ symbol: "vcb" });
+      expect(res.isError).toBeUndefined();
+      expect(stockMock.company).toHaveBeenCalledWith("VCB");
+      const data = JSON.parse(res.content[1].text);
+      expect(data.length).toBe(2);
     });
   });
 });

--- a/__tests__/cli/mcp/schemas.test.ts
+++ b/__tests__/cli/mcp/schemas.test.ts
@@ -1,8 +1,8 @@
 import { tools } from "../../../src/cli/mcp/tools";
 
 describe("MCP tool schemas", () => {
-  it("registers exactly 11 tools", () => {
-    expect(tools.length).toBe(11);
+  it("registers exactly 13 tools", () => {
+    expect(tools.length).toBe(13);
   });
 
   it("expected tool names present", () => {
@@ -17,6 +17,8 @@ describe("MCP tool schemas", () => {
         "is_trade_day",
         "get_trading_calendar",
         "get_company_info",
+        "get_dividends",
+        "get_corporate_events",
         "get_ai_context",
         "to_ai_prompt",
         "compare_symbols",

--- a/docs/releases/v1.4.1.md
+++ b/docs/releases/v1.4.1.md
@@ -1,0 +1,214 @@
+# Phiên bản v1.4.1
+
+Patch release tập trung vào trend-following indicators và stability.
+
+v1.4.1 bổ sung:
+- SuperTrend + Ichimoku Cloud
+- AI context bao gồm 2 indicator mới + smarter trend classifier
+- Cloudflare 1015 detection
+- TTL cache cho VCI static endpoints
+- Test stability (integration tests opt-in)
+
+---
+
+## New
+
+### SuperTrend
+
+Trend-following indicator chuẩn TradingView / pandas_ta. Default `period=10, multiplier=3`.
+
+```ts
+import { superTrend } from 'vnstock-js';
+
+const st = superTrend(history);
+// { date, superTrend, direction: "bullish" | "bearish", upperBand, lowerBand }
+```
+
+Direction flip khi `close` cross qua `superTrend` — tín hiệu trend reversal phổ biến trong VN swing trading.
+
+---
+
+### Ichimoku Cloud
+
+Đầy đủ 5 thành phần: Tenkan-sen, Kijun-sen, Senkou Span A/B, Chikou Span. Default `9 / 26 / 52 / 26`.
+
+```ts
+import { ichimoku, ichimokuFutureCloud } from 'vnstock-js';
+
+const ichi = ichimoku(history);
+// { date, tenkanSen, kijunSen, senkouSpanA, senkouSpanB, chikouSpan, cloudTop, cloudBottom }
+
+const future = ichimokuFutureCloud(history);
+// 26 bars tới: { offset, senkouSpanA, senkouSpanB, cloudTop, cloudBottom }
+```
+
+`senkouSpanA[i]` là **giá trị cloud hiện tại tại i** (đã shift forward 26 phiên từ tenkan/kijun ở i-26). Tiện để so sánh trực tiếp `close[i]` vs cloud.
+
+---
+
+### AI context mở rộng
+
+`aiContext()` và `toAIPrompt()` nay include SuperTrend + Ichimoku.
+
+```ts
+const ctx = await vnstock.stock.aiContext('VCB');
+
+ctx.indicators.superTrend;
+// { value: 89.12, direction: "bullish" }
+
+ctx.indicators.ichimoku;
+// { tenkanSen, kijunSen, cloudTop, cloudBottom, priceVsCloud: "above", tkCross: "bullish" }
+```
+
+Plain-text format cho non-MCP LLM:
+
+```txt
+SuperTrend: 89.12 (▲ TĂNG)
+Ichimoku: TK 90.50 / KJ 88.75 · Cloud [85.20 – 87.40] · Giá TRÊN mây · TK cross: bullish
+```
+
+---
+
+### Smarter trend classifier
+
+`classifyTrend()` giờ được confirm/penalize bởi SuperTrend + Ichimoku:
+
+- EMA bullish + ST bullish + price above cloud → `strength + 0.2` (boost)
+- EMA bullish nhưng ST bearish + price below cloud → `strength * 0.5` (contradict)
+- EMA neutral + ST & Ichimoku đồng thuận → upgrade direction (`strength = 0.4`)
+
+Rationale string thể hiện rõ:
+
+```txt
+"EMA20 > EMA50, slope EMA20 dương 5 phiên · ST + Ichimoku confirm bullish"
+```
+
+---
+
+### TTL cache cho VCI
+
+Giảm 30–50% requests trong dev/CI loop, hạn chế Cloudflare 1015.
+
+```ts
+import { VciAdapter } from 'vnstock-js';
+
+// Default (cache on)
+const adapter = new VciAdapter();
+
+// Opt-out
+const noCache = new VciAdapter({ cache: false });
+
+// Manual invalidation
+adapter.clearCache();
+```
+
+TTL:
+- `icb-codes` — 1 giờ
+- `search-bar` — 30 phút
+- `metrics` (per-symbol) — 1 giờ
+
+Endpoint động (financial statement, quote, news) **không** cache.
+
+---
+
+## Fixed
+
+### Cloudflare Error 1015 detection (#10)
+
+`pipeline/fetch.ts` detect Cloudflare rate-limit qua `cf-ray` header + body chứa `Error 1015` hoặc `cloudflare`. Throw `RateLimitError` thay `ApiError`, retry với exponential backoff **30s → 60s → 120s**.
+
+```ts
+import { RateLimitError } from 'vnstock-js';
+
+try {
+  await vnstock.stock.quote('VCB');
+} catch (e) {
+  if (e instanceof RateLimitError) {
+    // Cloudflare đang chặn, retry sau cooldown
+  }
+}
+```
+
+---
+
+### `goldPriceSJC()` deprecated (#12)
+
+SJC endpoint trả 403 từ non-VN IPs (đã skip test từ v1.3.3). Method giờ log warning, sẽ remove ở v2.0:
+
+```txt
+[vnstock-js] goldPriceSJC() is deprecated: SJC endpoint returns 403 from non-VN IPs.
+Use goldPriceBTMC() or goldPriceGiaVangNet() instead.
+```
+
+Chuyển sang:
+
+```ts
+await vnstock.commodity.goldPriceBTMC();
+await vnstock.commodity.goldPriceGiaVangNet();
+```
+
+---
+
+### Test stability — `INTEGRATION=1` gate (#9)
+
+3 test suite `listing` / `company` / `financial` không còn hit Vietcap REST mặc định. CI fast + stable.
+
+```bash
+# Default: mock-based
+npm test
+
+# Real-API verification (trước release):
+INTEGRATION=1 npm test
+```
+
+---
+
+## Migration
+
+Không breaking. Lưu ý:
+
+- `aiContext` JSON nay thêm 2 field (`superTrend`, `ichimoku`), ~200 bytes mỗi response.
+- `VciAdapter` mặc định bật cache. Code cũ phụ thuộc fresh API mỗi call cho metrics/ICB/search-bar: pass `{ cache: false }` hoặc gọi `clearCache()`.
+- Tests cần real-API verification: `INTEGRATION=1 npm test`.
+
+---
+
+## Install
+
+```bash
+npm install vnstock-js@1.4.1
+
+# CLI global
+npm install -g vnstock-js@1.4.1
+```
+
+---
+
+## Tests
+
+- 45 test suites, 383 pass / 18 skip (integration-gated) / 0 fail
+- +43 tests vs v1.4.0
+
+---
+
+## Credits
+
+- Vietcap REST API — primary market data source
+- TradingView / pandas_ta — SuperTrend reference parity
+- Issues #9, #10, #11, #12 contributors
+
+---
+
+## Links
+
+- npm: https://www.npmjs.com/package/vnstock-js
+- docs: https://vnstock-js.vercel.app
+- issues: https://github.com/ttqteo/vnstock-js/issues
+
+---
+
+## Disclaimer
+
+vnstock-js cung cấp market data và technical analysis primitives.
+
+Không phải lời khuyên đầu tư. User judgment là quyết định cuối cùng.

--- a/docs/releases/v1.4.2.md
+++ b/docs/releases/v1.4.2.md
@@ -1,0 +1,85 @@
+# Phiên bản v1.4.2
+
+Patch hotfix thuần additive, không breaking. Tập trung vào dữ liệu cổ tức/sự kiện doanh nghiệp qua MCP và sửa export thiếu cho indicators v2.
+
+v1.4.2 bổ sung:
+- MCP tool `get_dividends` + `get_corporate_events`
+- Backfill root export `macd` / `bollinger` / `atr` (+ `ichimokuFutureCloud`)
+
+---
+
+## New
+
+### MCP: Cổ tức & sự kiện doanh nghiệp
+
+SDK đã có `company.dividends()` / `company.events()` từ lâu, nhưng MCP server chỉ expose `get_company_info` (tên/sàn/ngành). Daily-report pipeline chạy qua MCP vì vậy không thấy được lịch cổ tức. v1.4.2 wire 2 method này thành MCP tool.
+
+**`get_dividends`** — lịch sử & lịch chia cổ tức (tiền mặt + cổ phiếu):
+
+```
+Claude prompt: "ACB chia cổ tức khi nào? Tỉ lệ bao nhiêu?"
+```
+
+Trả mảng `CorporateEvent` đã lọc cổ tức, mỗi phần tử gồm:
+- `eventType` — loại cổ tức (tiền/cổ phiếu)
+- `ratio` / `value` — tỉ lệ / giá trị
+- `exRightDate` — ngày giao dịch không hưởng quyền (GDKHQ)
+- `recordDate` — ngày chốt danh sách
+
+**`get_corporate_events`** — tất cả sự kiện doanh nghiệp (cổ tức, ĐHCĐ, phát hành thêm, niêm yết, giao dịch nội bộ):
+
+```
+Claude prompt: "HPG có sự kiện gì sắp tới?"
+```
+
+MCP server nay đăng ký **13 tools** (trước 11). Cả 2 bilingual (Vi + En).
+
+---
+
+## Fixed
+
+### Root export thiếu macd / bollinger / atr
+
+3 indicator v2 đã có trong `src/indicators/index.ts` từ v1.4.0 nhưng `src/index.ts` quên re-export — buộc phải import từ subpath `vnstock-js/dist/indicators/*`. Nay export thẳng từ root:
+
+```ts
+import { sma, ema, rsi, macd, bollinger, atr, superTrend, ichimoku, ichimokuFutureCloud } from 'vnstock-js';
+```
+
+Fix này cũng làm đúng ví dụ import trong docs indicators (vốn đã ghi import từ root nhưng trước đó chạy lỗi).
+
+---
+
+## Migration
+
+Không breaking. Lưu ý:
+
+- Nếu trước đây import `macd`/`bollinger`/`atr` từ `vnstock-js/dist/indicators/*`, code cũ vẫn chạy; nay có thể chuyển sang root import.
+- 2 MCP tool mới opt-in, không ảnh hưởng tool cũ.
+
+---
+
+## Install
+
+```bash
+npm install vnstock-js@1.4.2
+
+# CLI global
+npm install -g vnstock-js@1.4.2
+```
+
+---
+
+## Links
+
+- npm: https://www.npmjs.com/package/vnstock-js
+- docs: https://vnstock-js.vercel.app
+- issues: https://github.com/ttqteo/vnstock-js/issues
+
+---
+
+## Disclaimer
+
+vnstock-js cung cấp market data và technical analysis primitives.
+
+Không phải lời khuyên đầu tư. User judgment là quyết định cuối cùng.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vnstock-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/cli/mcp/handlers.ts
+++ b/src/cli/mcp/handlers.ts
@@ -164,6 +164,30 @@ export async function handleGetCompanyInfo(args: any): Promise<McpToolResponse> 
   }
 }
 
+export async function handleGetDividends(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  try {
+    var dividends = await vnstock.stock.company(symbol).dividends();
+    var summary = `${symbol} — ${dividends.length} sự kiện cổ tức`;
+    return textResponse(summary, dividends);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi lấy cổ tức ${symbol}: ${e.message || e}`);
+  }
+}
+
+export async function handleGetCorporateEvents(args: any): Promise<McpToolResponse> {
+  var symbol = String(args.symbol || "").toUpperCase().trim();
+  if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
+  try {
+    var events = await vnstock.stock.company(symbol).events();
+    var summary = `${symbol} — ${events.length} sự kiện doanh nghiệp`;
+    return textResponse(summary, events);
+  } catch (e: any) {
+    return errorResponse(`Lỗi khi lấy sự kiện ${symbol}: ${e.message || e}`);
+  }
+}
+
 export async function handleGetAIContext(args: any): Promise<McpToolResponse> {
   var symbol = String(args.symbol || "").toUpperCase().trim();
   if (!symbol) return errorResponse("Thiếu tham số 'symbol'.");
@@ -218,6 +242,8 @@ export const handlers: Record<string, (args: any) => Promise<McpToolResponse>> =
   is_trade_day: handleIsTradeDay,
   get_trading_calendar: handleGetTradingCalendar,
   get_company_info: handleGetCompanyInfo,
+  get_dividends: handleGetDividends,
+  get_corporate_events: handleGetCorporateEvents,
   get_ai_context: handleGetAIContext,
   to_ai_prompt: handleToAIPrompt,
   compare_symbols: handleCompareSymbols,

--- a/src/cli/mcp/tools.ts
+++ b/src/cli/mcp/tools.ts
@@ -118,6 +118,36 @@ export const tools: ToolSchema[] = [
     },
   },
   {
+    name: "get_dividends",
+    description:
+      "Lấy lịch sử & lịch chia cổ tức của 1 mã (tiền mặt + cổ phiếu). " +
+      "Trả về loại cổ tức, tỉ lệ/giá trị, ngày giao dịch không hưởng quyền (GDKHQ/exRightDate), ngày chốt danh sách (recordDate). " +
+      "Dùng khi user hỏi 'ACB chia cổ tức khi nào', 'lịch cổ tức VNM', 'cổ tức năm nay của FPT'. " +
+      "EN: Get dividend history & schedule (cash + stock) for a Vietnam stock: type, ratio, ex-rights date, record date.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
+    name: "get_corporate_events",
+    description:
+      "Lấy tất cả sự kiện doanh nghiệp của 1 mã: cổ tức, ĐHCĐ, phát hành thêm, niêm yết, giao dịch nội bộ... " +
+      "Mỗi sự kiện gồm loại (eventType), tiêu đề, ngày GDKHQ, ngày chốt quyền, tỉ lệ/giá trị. " +
+      "Dùng khi user hỏi 'sự kiện sắp tới của HPG', 'lịch ĐHCĐ VCB', 'VCB có sự kiện gì'. " +
+      "EN: Get all corporate events for a Vietnam stock: dividends, AGM, issuance, insider deals, with ex-rights/record dates.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        symbol: { type: "string", description: "Mã cổ phiếu" },
+      },
+      required: ["symbol"],
+    },
+  },
+  {
     name: "get_ai_context",
     description:
       "Lấy bối cảnh phân tích kỹ thuật cho 1 mã, dạng structured JSON. " +

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export const realtime = { create: createRealtime, parseData };
 export { RealtimeClient };
 export { Vnstock };
 export { init };
-export { sma, ema, rsi, superTrend, ichimoku } from "./indicators";
+export { sma, ema, rsi, macd, bollinger, atr, superTrend, ichimoku, ichimokuFutureCloud } from "./indicators";
 
 export type { ScreenFilter, ScreenOptions, ScreenResult } from "./models/screening";
 export type { StockDataAdapter } from "./adapters/types";


### PR DESCRIPTION
## v1.4.2 - Dividend MCP Tools + Indicator Export Fix

Patch thuần additive, không breaking.

### Thêm
- MCP tool `get_dividends` - wrap `company().dividends()`: lịch sử & lịch chia cổ tức (tiền mặt + cổ phiếu), gồm eventType, ratio, value, exRightDate (GDKHQ), recordDate.
- MCP tool `get_corporate_events` - wrap `company().events()`: tất cả sự kiện doanh nghiệp (cổ tức, ĐHCĐ, phát hành, niêm yết, giao dịch nội bộ).
- MCP server: 11 -> 13 tools (bilingual Vi/En).

### Sửa
- Root export backfill `macd` / `bollinger` / `atr` + `ichimokuFutureCloud` trong `src/index.ts` (trước phải import từ subpath `dist/indicators/*`). Fix luôn ví dụ import sai trong docs indicators.

### Test
- 45 suites, 388 pass / 18 skip / 0 fail (+5 MCP handler tests). Build clean, dist verified.

Release notes: `docs/releases/v1.4.2.md`