### PR TITLE
v1.4.3 - quote history turnover (value) + batch multi-symbol (symbol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.4.3 — Giá trị giao dịch theo bar + history batch nhiều mã
+
+Patch thuần additive, không breaking. Bổ sung giá trị giao dịch (turnover) cho từng bar và mở khóa batch nhiều mã trong `quote.history()`.
+
+### Thêm
+
+- **`QuoteHistory.value`** — trường optional mới, ánh xạ từ `accumulatedValue` của VCI. **Đơn vị: TRIỆU VND** (giữ nguyên raw, không scale như giá). Có mặt trên mọi bar khi VCI trả về; tự động xuất hiện trong output MCP `get_history` và CLI `history` vì cùng dùng `QuoteHistory`. Khi VCI không trả `accumulatedValue`, `value` là `undefined`.
+- **`QuoteHistory.symbol`** — trường optional mới, mang mã CK của từng bar. Endpoint chart VCI vốn nhận mảng `symbols` và trả về trong **1 request**, nhưng trước đây transform vứt mất `symbol` nên kết quả batch không phân biệt được mã nào. Nay `quote.history({ symbols: ["VCI","FPT",...] })` trả mảng phẳng vẫn demux được theo `symbol` → gọi 1 request cho cả danh sách thay vì N request (giảm tải, tránh 429). Khuyến nghị batch ở mức hợp lý (vài chục mã/call) để tránh payload lớn timeout 15s.
+
+### Nội bộ
+
+- +4 test transform: ánh xạ `accumulatedValue → value` (đúng độ lớn, không scale), `value` undefined khi thiếu field, `symbol` mang theo mỗi bar để demux batch, và `symbol` undefined khi raw không có.
+
+### Migration notes
+
+- Không breaking. `value` và `symbol` đều optional; code cũ không đụng tới chúng vẫn chạy như trước.
+
 ## 1.4.2 — Dividend MCP Tools + Indicator Export Fix
 
 Patch thuần additive, không breaking. Expose lịch cổ tức/sự kiện doanh nghiệp qua MCP và backfill root export cho indicators v2.

--- a/__tests__/pipeline/configs.test.ts
+++ b/__tests__/pipeline/configs.test.ts
@@ -21,21 +21,67 @@ describe("transformQuoteHistory", () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
+      symbol: "VCI",
       date: "2024-01-15",
       open: 25.5,
       high: 26.0,
       low: 25.0,
       close: 25.8,
       volume: 1000000,
+      value: 25500000,
     });
     expect(result[1]).toEqual({
+      symbol: "VCI",
       date: "2024-01-16",
       open: 25.8,
       high: 26.2,
       low: 25.3,
       close: 26.1,
       volume: 1200000,
+      value: 57300000,
     });
+  });
+
+  it("carries symbol on every bar so batched multi-symbol history is demuxable", () => {
+    const vci = transformQuoteHistory({
+      symbol: "VCI",
+      o: [25500], h: [26000], l: [25000], c: [25800], v: [1000000], t: [1705276800],
+    });
+    const fpt = transformQuoteHistory({
+      symbol: "FPT",
+      o: [120000], h: [121000], l: [119000], c: [120500], v: [2000000], t: [1705276800],
+    });
+    const merged = [...vci, ...fpt];
+    expect(merged.map((r) => r.symbol)).toEqual(["VCI", "FPT"]);
+  });
+
+  it("leaves symbol undefined when raw has no symbol field", () => {
+    const result = transformQuoteHistory({
+      o: [25500], h: [26000], l: [25000], c: [25800], v: [1000000], t: [1705276800],
+    });
+    expect(result[0].symbol).toBeUndefined();
+  });
+
+  it("maps accumulatedValue to value (đơn vị triệu VND, không scale)", () => {
+    const rawChartData = {
+      symbol: "VCI",
+      o: [25500], h: [26000], l: [25000], c: [25800],
+      v: [1000000], t: [1705276800],
+      accumulatedValue: [90482.55],
+    };
+    const result = transformQuoteHistory(rawChartData);
+    expect(result[0].value).toBe(90482.55);
+  });
+
+  it("leaves value undefined when accumulatedValue is absent", () => {
+    const rawChartData = {
+      symbol: "VCI",
+      o: [25500], h: [26000], l: [25000], c: [25800],
+      v: [1000000], t: [1705276800],
+    };
+    const result = transformQuoteHistory(rawChartData);
+    expect(result[0].value).toBeUndefined();
+    expect("value" in result[0]).toBe(true);
   });
 
   it("returns empty array for empty data", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vnstock-js",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/src/models/normalized.ts
+++ b/src/models/normalized.ts
@@ -1,11 +1,13 @@
 
 export interface QuoteHistory {
+  symbol?: string;  // mã CK của bar; chỉ có ý nghĩa khi history() gọi batch nhiều mã 1 request
   date: string;
   open: number;
   high: number;
   low: number;
   close: number;
   volume: number;
+  value?: number;   // giá trị giao dịch của bar (accumulatedValue từ VCI), đơn vị TRIỆU VND
 }
 
 

--- a/src/pipeline/transform/configs/quote.ts
+++ b/src/pipeline/transform/configs/quote.ts
@@ -19,12 +19,14 @@ export const quoteTransformConfig: TransformConfig = {
 };
 
 export function transformQuoteHistory(raw: {
+  symbol?: string;
   o: number[];
   h: number[];
   l: number[];
   c: number[];
   v: number[];
   t: number[];
+  accumulatedValue?: number[];
   [key: string]: unknown;
 }): QuoteHistory[] {
   const length = raw.t?.length ?? 0;
@@ -32,12 +34,14 @@ export function transformQuoteHistory(raw: {
 
   for (let i = 0; i < length; i++) {
     result.push({
+      symbol: raw.symbol,
       date: format(fromUnixTime(raw.t[i]), "yyyy-MM-dd"),
       open: raw.o[i] / 1000,
       high: raw.h[i] / 1000,
       low: raw.l[i] / 1000,
       close: raw.c[i] / 1000,
       volume: raw.v[i],
+      value: raw.accumulatedValue?.[i],
     });
   }
 


### PR DESCRIPTION
Patch thuần additive, không breaking.

## Thêm

- **`QuoteHistory.value`** — ánh xạ từ `accumulatedValue` của VCI. **Đơn vị: TRIỆU VND** (giữ raw, không scale như giá). Tự động xuất hiện trong MCP `get_history`, CLI `history --json/--csv` vì dùng chung `QuoteHistory`. `undefined` khi VCI không trả field.
- **`QuoteHistory.symbol`** — mang mã CK theo từng bar. Endpoint chart VCI vốn nhận mảng `symbols` và trả trong 1 request, nhưng trước đây transform vứt mất `symbol` nên kết quả batch không demux được. Nay `quote.history({ symbols: [...] })` trả mảng phẳng vẫn nhóm được theo `symbol` → 1 request cho cả danh sách thay vì N (giảm tải, tránh 429).

## Test

- +4 test transform; full suite 45/45 pass; `tsc --noEmit` sạch.

## Migration

- Không breaking. `value` và `symbol` đều optional.